### PR TITLE
Add status badges to the readme

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -44,6 +44,5 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,6 +1,14 @@
 name: Check code quality
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: '0 4 * * *'
 
 jobs:
   build:

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -10,9 +10,29 @@ on:
   schedule:
     - cron: '0 4 * * *'
 
+permissions:
+  actions: write  # Needed for skip-duplicate-jobs job
+  contents: read
+
 jobs:
+  # Special job which automatically cancels old runs for the same branch, prevents runs for the
+  # same file set which has already passed, etc.
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
+        with:
+          cancel_others: 'true'
+          github_token: ${{ github.token }}
+
   build:
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'main' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/secrets-scanner.yaml
+++ b/.github/workflows/secrets-scanner.yaml
@@ -1,9 +1,30 @@
 name: TruffleHog Secrets Scan
 on: [push, pull_request]
 
+permissions:
+  actions: write  # Needed for skip-duplicate-jobs job
+  contents: read
+
 jobs:
+  # Special job which automatically cancels old runs for the same branch, prevents runs for the
+  # same file set which has already passed, etc.
+  pre_job:
+    name: Skip Duplicate Jobs Pre Job
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - id: skip_check
+        uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0
+        with:
+          cancel_others: 'true'
+          github_token: ${{ github.token }}
+
   TruffleHog:
     runs-on: ubuntu-latest
+    needs: pre_job
+    if: ${{ needs.pre_job.outputs.should_skip != 'true' || github.ref_name == 'main' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # DataSet-Go
 
+[![Check code quality](https://github.com/scalyr/dataset-go/actions/workflows/code-quality.yaml/badge.svg)](https://github.com/scalyr/dataset-go/actions/workflows/code-quality.yaml) [![TruffleHog Secrets Scan](https://github.com/scalyr/dataset-go/actions/workflows/secrets-scanner.yaml/badge.svg)](https://github.com/scalyr/dataset-go/actions/workflows/secrets-scanner.yaml) [![codecov](https://codecov.io/gh/scalyr/dataset-go/branch/main/graph/badge.svg?token=IFTJDLGEF5)](https://codecov.io/gh/scalyr/dataset-go)
+
 This repository holds the source code for the Go wrapper around [DataSet API](https://app.scalyr.com/help/api).
 
 To learn more about DataSet, visit https://www.dataset.com.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+codecov:
+  # Avoid "Missing base report" issues
+  allow_coverage_offsets: true
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2         # decimal places to display: 0 <= value <= 4
+  round: nearest
+  range: 50...90      # custom range of coverage colors from red -> yellow -> green
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+        base: auto
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        base: auto
+
+github_checks:
+    annotations: false
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: yes
+  require_head: yes


### PR DESCRIPTION
This pull request adds GHA workflow and codecov.io status badge to the readme.

It also removes codecov token from the workflow - this token is not needed anymore for integration now that this repo is public.