### PR TITLE
DSET-3572: Fix data race

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -61,10 +61,12 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run -a
-      - name: Code coverage Lib
+      - name: Code tests
         run: |
-          go test ./... -coverprofile coverage.out -covermode count
-          go tool cover -func coverage.out
+          make test
+      - name: Code coverage
+        run: |
+          make coverage
       - name: Build Examples
         run: |
           ( cd examples/client; go build )

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# build options are from https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/Makefile.Common
+# to make out library compatible with open telemetry
+GO_BUILD_TAGS=""
+GOTEST_OPT?= -race -timeout 300s -parallel 4 --tags=$(GO_BUILD_TAGS)
+GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
+GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
+GOCMD?= go
+GOTEST=$(GOCMD) test
+
+.DEFAULT_GOAL := pre-commit-run
+
+.PHONY: pre-commit-install
+pre-commit-install:
+	pre-commit install
+	./scripts/install-dev-tools.sh
+
+.PHONY: pre-commit-run
+pre-commit-run:
+	pre-commit run -a
+
 build:
 	echo "Done"
 
+.PHONY: test
 test:
-	go test ./...
+	$(GOTEST) $(GOTEST_OPT) ./...
 
+.PHONY: coverage
 coverage:
-	go test ./... -coverprofile coverage.out -covermode count
-	go tool cover -func coverage.out
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...
+	$(GOCMD) tool cover -html=coverage.txt -o coverage.html

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -100,7 +100,7 @@ func (client *DataSetClient) SendAddEventsBuffer(buf *buffer.Buffer) (*add_event
 
 	payload, err := buf.Payload()
 	if err != nil {
-		client.Logger.Error("Cannot create payload", buf.ZapStats(zap.Error(err))...)
+		client.Logger.Warn("Cannot create payload", buf.ZapStats(zap.Error(err))...)
 		return nil, fmt.Errorf("cannot create payload: %w", err)
 	}
 	client.Logger.Debug("Created payload",

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -32,32 +32,9 @@ import (
 	"go.uber.org/zap"
 )
 
-/**
+/*
 Wrapper around: https://app.scalyr.com/help/api#addEvents
-
 */
-
-func (client *DataSetClient) DangerousNaiveAddEvents(events []*add_events.Event, threads []*add_events.Thread, session string, sessionInfo *add_events.SessionInfo) (*add_events.AddEventsResponse, error) {
-	apiResponse := &add_events.AddEventsResponse{}
-	apiRequest := &add_events.AddEventsRequest{
-		AddEventsRequestParams: add_events.AddEventsRequestParams{
-			Session:     session,
-			SessionInfo: sessionInfo,
-			Events:      events,
-			Threads:     threads,
-		},
-	}
-	httpRequest, err := request.NewRequest(
-		"POST",
-		client.Config.Endpoint+"/api/addEvents",
-	).WithWriteLog(client.Config.Tokens).JsonRequest(apiRequest).HttpRequest()
-	if err != nil {
-		return nil, fmt.Errorf("cannot create request: %w", err)
-	}
-
-	err = client.apiCall(httpRequest, apiResponse)
-	return apiResponse, err
-}
 
 func (client *DataSetClient) AddEvents(bundles []*add_events.EventBundle) error {
 	errR := client.shouldRejectNextBatch()

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -205,6 +205,7 @@ func (s *SuiteAddEvents) TestAddEventsRetryAfterSec(assert, require *td.T) {
 		}
 	}
 	assert.CmpNoError(err1)
+	assert.CmpNoError(sc.LastError())
 	info1 := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info1, map[string]int{"POST https://example.com/api/addEvents": 2})
 
@@ -223,11 +224,11 @@ func (s *SuiteAddEvents) TestAddEventsRetryAfterSec(assert, require *td.T) {
 		}
 	}
 	assert.CmpNoError(err2)
+	assert.CmpNoError(sc.LastError())
 	info2 := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info2, map[string]int{"POST https://example.com/api/addEvents": 3})
 }
 
-/*
 func (s *SuiteAddEvents) TestAddEventsRetryAfterTime(assert, require *td.T) {
 	attempt := atomic.Int32{}
 	attempt.Store(0)
@@ -291,10 +292,10 @@ func (s *SuiteAddEvents) TestAddEventsRetryAfterTime(assert, require *td.T) {
 		}
 	}
 	assert.CmpNoError(err)
+	assert.CmpNoError(sc.LastError())
 	info := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": 2})
 }
-*/
 
 func (s *SuiteAddEvents) TestAddEventsLargeEvent(assert, require *td.T) {
 	originalAttrs := make(map[string]interface{})
@@ -384,6 +385,7 @@ func (s *SuiteAddEvents) TestAddEventsLargeEvent(assert, require *td.T) {
 		}
 	}
 	assert.CmpNoError(err)
+	assert.CmpNoError(sc.LastError())
 	info := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": 1})
 }
@@ -470,6 +472,7 @@ func (s *SuiteAddEvents) TestAddEventsLargeEventThatNeedEscaping(assert, require
 		}
 	}
 	assert.CmpNoError(err)
+	assert.CmpNoError(sc.LastError())
 	info := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": 1})
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -41,7 +41,7 @@ const (
 	HttpErrorHasErrorMessage = 499
 )
 
-func IsRetryableStatus(status uint16) bool {
+func IsRetryableStatus(status uint32) bool {
 	return status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
 
@@ -52,9 +52,11 @@ type DataSetClient struct {
 	SessionInfo    *add_events.SessionInfo
 	buffer         sync.Map
 	PubSub         *pubsub.PubSub
-	LastHttpStatus uint16
-	LastError      error
-	RetryAfter     time.Time
+	LastHttpStatus atomic.Uint32
+	lastError      error
+	lastErrorMu    sync.RWMutex
+	retryAfter     time.Time
+	retryAfterMu   sync.RWMutex
 	Logger         *zap.Logger
 }
 
@@ -105,20 +107,20 @@ func (client *DataSetClient) ListenAndSendBufferForSession(session string, ch ch
 			)
 			buf, ok := msg.(*buffer.Buffer)
 			if ok {
-				for client.RetryAfter.After(time.Now()) {
-					client.sleep(client.RetryAfter, buf)
+				for client.RetryAfter().After(time.Now()) {
+					client.sleep(client.RetryAfter(), buf)
 				}
 				response, err := client.SendAddEventsBuffer(buf)
-				client.LastError = err
-				lastHttpStatus := uint16(0)
+				client.SetLastError(err)
+				lastHttpStatus := uint32(0)
 				if err != nil {
 					client.Logger.Error("unable to send addEvents buffers", zap.Error(err))
 					if strings.Contains(err.Error(), "Unable to send request") {
 						lastHttpStatus = HttpErrorCannotConnect
-						client.LastHttpStatus = lastHttpStatus
+						client.LastHttpStatus.Store(lastHttpStatus)
 					} else {
 						lastHttpStatus = HttpErrorHasErrorMessage
-						client.LastHttpStatus = lastHttpStatus
+						client.LastHttpStatus.Store(lastHttpStatus)
 						continue
 					}
 				}
@@ -129,8 +131,8 @@ func (client *DataSetClient) ListenAndSendBufferForSession(session string, ch ch
 						zap.String("httpStatus", response.ResponseObj.Status),
 						zap.Int("httpCode", response.ResponseObj.StatusCode),
 					)
-					lastHttpStatus = uint16(response.ResponseObj.StatusCode)
-					client.LastHttpStatus = lastHttpStatus
+					lastHttpStatus = uint32(response.ResponseObj.StatusCode)
+					client.LastHttpStatus.Store(lastHttpStatus)
 				}
 
 				zaps = append(
@@ -155,7 +157,7 @@ func (client *DataSetClient) ListenAndSendBufferForSession(session string, ch ch
 						// retry after is specified, we should update
 						// client state, so we do not send more requests
 
-						client.RetryAfter = retryAfter
+						client.SetRetryAfter(retryAfter)
 					}
 
 					client.sleep(retryAfter, buf)
@@ -229,8 +231,8 @@ func (client *DataSetClient) PublishBuffer(buf *buffer.Buffer) *buffer.Buffer {
 }
 
 func (client *DataSetClient) shouldRejectNextBatch() error {
-	if IsRetryableStatus(client.LastHttpStatus) {
-		err := client.LastError
+	if IsRetryableStatus(client.LastHttpStatus.Load()) {
+		err := client.LastError()
 		if err != nil {
 			return fmt.Errorf("rejecting - Last HTTP request contains an error: %w", err)
 		} else {
@@ -238,8 +240,8 @@ func (client *DataSetClient) shouldRejectNextBatch() error {
 		}
 	}
 
-	if client.RetryAfter.After(time.Now()) {
-		return fmt.Errorf("rejecting - should retry after %s", client.RetryAfter.Format(time.RFC1123))
+	if client.RetryAfter().After(time.Now()) {
+		return fmt.Errorf("rejecting - should retry after %s", client.RetryAfter().Format(time.RFC1123))
 	}
 
 	return nil
@@ -280,8 +282,10 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 		Config:         cfg,
 		Client:         client,
 		PubSub:         pubsub.New(0),
-		LastHttpStatus: 0,
-		RetryAfter:     time.Now(),
+		LastHttpStatus: atomic.Uint32{},
+		retryAfter:     time.Now(),
+		retryAfterMu:   sync.RWMutex{},
+		lastErrorMu:    sync.RWMutex{},
 		Logger:         logger,
 	}
 
@@ -352,4 +356,28 @@ func (client *DataSetClient) sleep(retryAfter time.Time, buffer *buffer.Buffer) 
 		zap.String("bufferSession", buffer.Session),
 	)
 	time.Sleep(sleepFor)
+}
+
+func (client *DataSetClient) LastError() error {
+	client.lastErrorMu.RLock()
+	defer client.lastErrorMu.RUnlock()
+	return client.lastError
+}
+
+func (client *DataSetClient) SetLastError(err error) {
+	client.lastErrorMu.Lock()
+	defer client.lastErrorMu.Unlock()
+	client.lastError = err
+}
+
+func (client *DataSetClient) RetryAfter() time.Time {
+	client.retryAfterMu.RLock()
+	defer client.retryAfterMu.RUnlock()
+	return client.retryAfter
+}
+
+func (client *DataSetClient) SetRetryAfter(t time.Time) {
+	client.retryAfterMu.Lock()
+	defer client.retryAfterMu.Unlock()
+	client.retryAfter = t
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -110,6 +110,10 @@ func (client *DataSetClient) ListenAndSendBufferForSession(session string, ch ch
 				for client.RetryAfter().After(time.Now()) {
 					client.sleep(client.RetryAfter(), buf)
 				}
+				if !buf.HasEvents() {
+					client.Logger.Warn("Buffer is empty, skipping", buf.ZapStats()...)
+					continue
+				}
 				response, err := client.SendAddEventsBuffer(buf)
 				client.SetLastError(err)
 				lastHttpStatus := uint32(0)
@@ -145,7 +149,7 @@ func (client *DataSetClient) ListenAndSendBufferForSession(session string, ch ch
 				)
 
 				if IsRetryableStatus(lastHttpStatus) {
-					// check whether header is specified and get it's value
+					// check whether header is specified and get its value
 					retryAfter, specified := client.getRetryAfter(
 						response.ResponseObj,
 						time.Duration(


### PR DESCRIPTION
# 🥅 Goal

Fix data race - https://go.dev/doc/articles/race_detector - that was detected when I was trying to use this library in the `opentelemetry-collector-contrib` repository - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20870.

# 🛠️ Solution

I have used the same flags that are used by contrib repository - `-race -timeout 300s -parallel 4` - and fixed the problems in the library.

Majority of the problems were in the tests itself. Only the variables related to error propagation have been fixed.

# 🏫 Testing

Run the unit tests - `make coverage` and `make test` to make sure that everything is passing now.