### PR TITLE
DSET-1556: Add test to check that each event is processed once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,10 @@
 *.out
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
+
+# log files
+out*.log
+
+.idea
+coverage*

--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ endif
 
 GO_BUILD_TAGS=""
 GOTEST_OPT?= -race -timeout 300s -parallel 4 -count=1 --tags=$(GO_BUILD_TAGS)
-GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
+GOTEST_LONG_RUNNING_OPT?= -race -timeout 360s -parallel 4 -count=1 -tags=long_running,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration -coverprofile=integration-coverage.txt -covermode=atomic
+GOTEST_OPT_WITH_COVERAGE_LONG_RUNNING=$(GOTEST_LONG_RUNNING_OPT) -coverprofile=coverage.txt -covermode=atomic
 GOCMD?= go
 GOTEST=$(GOCMD) test
 
@@ -45,8 +45,15 @@ build:
 	echo "Done"
 
 .PHONY: test
-test:
+test: test-all
+
+.PHONY: test-unit
+test-unit:
 	$(GOTEST) $(GOTEST_OPT) ./...
+
+.PHONY: test-all
+test-all:
+	$(GOTEST) $(GOTEST_LONG_RUNNING_OPT) ./...
 
 .PHONY: test-many-times
 test-many-times:
@@ -63,6 +70,15 @@ test-many-times:
 
 
 .PHONY: coverage
-coverage:
+coverage: coverage-all
+
+.PHONY: coverage-unit
+coverage-unit:
 	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE) ./...
+	$(GOCMD) tool cover -html=coverage.txt -o coverage.html
+
+
+.PHONY: coverage-all
+coverage-all:
+	$(GOTEST) $(GOTEST_OPT_WITH_COVERAGE_LONG_RUNNING) ./...
 	$(GOCMD) tool cover -html=coverage.txt -o coverage.html

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ test-many-times:
   	fi; \
   	for i in `seq 1 $${COUNT}`; do \
   		echo "Running test $${i} / $${COUNT}"; \
-  		make test; \
+  		make test 2>&1 | tee out-test-$${i}.log; \
   	done;
 
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.0.4 Fix Concurrency Issues
+
+* sometimes not all events have been delivered exactly once
+
 ## 0.0.3 Fix Data Races
 
 * fixed [data races](https://go.dev/doc/articles/race_detector)

--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -50,6 +50,10 @@ func (s Status) String() string {
 	return [...]string{"Initialising", "Ready", "AddingBundles", "Publishing", "Retrying"}[s]
 }
 
+func (s Status) IsActive() bool {
+	return s == Ready || s == AddingBundles
+}
+
 type AddStatus uint8
 
 const (
@@ -418,14 +422,14 @@ func (buffer *Buffer) ZapStats(fields ...zap.Field) []zap.Field {
 	return res
 }
 
-func (buffer *Buffer) HasStatus(status Status) bool {
-	return buffer.status.Load() == uint32(status)
-}
-
 func (buffer *Buffer) SetStatus(status Status) {
 	buffer.status.Store(uint32(status))
 }
 
 func (buffer *Buffer) Status() Status {
 	return Status(buffer.status.Load())
+}
+
+func (buffer *Buffer) HasStatus(status Status) bool {
+	return buffer.status.Load() == uint32(status)
 }

--- a/pkg/buffer/buffer.go
+++ b/pkg/buffer/buffer.go
@@ -79,9 +79,10 @@ type Buffer struct {
 	Session string
 	Token   string
 
-	Attempt   uint
-	createdAt atomic.Int64
-	status    atomic.Uint32
+	Attempt     uint
+	createdAt   atomic.Int64
+	status      atomic.Uint32
+	PublishAsap atomic.Bool
 
 	sessionInfo *add_events.SessionInfo
 	threads     map[string]*add_events.Thread
@@ -107,6 +108,7 @@ func NewEmptyBuffer(session string, token string) *Buffer {
 		Token:        token,
 		status:       atomic.Uint32{},
 		Attempt:      0,
+		PublishAsap:  atomic.Bool{},
 		countThreads: atomic.Int32{},
 		countLogs:    atomic.Int32{},
 		countEvents:  atomic.Int32{},

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -131,7 +131,18 @@ func (s *SuiteAddEventsLongRunning) TestAddEventsManyLogsShouldSucceed(assert, r
 				Ts:     fmt.Sprintf("%d", time.Now().Nanosecond()),
 				Attrs:  attrs,
 			}
-			eventBundle := &add_events.EventBundle{Event: event, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
+
+			thread := &add_events.Thread{
+				Id:   "5",
+				Name: "fred",
+			}
+			log := &add_events.Log{
+				Id: "LO",
+				Attrs: map[string]interface{}{
+					"key": strings.Repeat("A", rand.Intn(200)),
+				},
+			}
+			eventBundle := &add_events.EventBundle{Event: event, Thread: thread, Log: log}
 
 			batch = append(batch, eventBundle)
 			expectedKeys[key] = 1

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -162,7 +162,7 @@ func (s *SuiteAddEventsLongRunning) TestAddEventsManyLogsShouldSucceed(assert, r
 
 	assert.True(wasSuccessful.Load())
 
+	assert.Cmp(seenKeys, expectedKeys)
 	assert.Cmp(processedEvents.Load(), ExpectedLogs, "processed items")
 	assert.Cmp(uint64(len(seenKeys)), ExpectedLogs, "unique items")
-	assert.Cmp(seenKeys, expectedKeys)
 }

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -1,0 +1,126 @@
+//go:build long_running
+
+/*
+ * Copyright 2023 SentinelOne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/scalyr/dataset-go/pkg/api/add_events"
+	"github.com/scalyr/dataset-go/pkg/config"
+	"go.uber.org/zap"
+
+	"github.com/jarcoal/httpmock"
+	"github.com/maxatome/go-testdeep/td"
+)
+
+func (s *SuiteAddEvents) TestAddEventsManyLogsShouldSucceed(assert, require *td.T) {
+	const MaxDelayMs = 200
+	config := &config.DataSetConfig{
+		Endpoint:       "https://example.com",
+		Tokens:         config.DataSetTokens{WriteLog: "AAAA"},
+		MaxPayloadB:    1000,
+		MaxBufferDelay: time.Duration(MaxDelayMs) * time.Millisecond,
+		RetryBase:      RetryBase,
+	}
+	sc, _ := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+
+	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
+	sc.SessionInfo = sessionInfo
+
+	const MaxBatchCount = 20
+	const LogsPerBatch = 10000
+	const ExpectedLogs = uint64(MaxBatchCount * LogsPerBatch)
+
+	attempt := atomic.Uint64{}
+	wasSuccessful := atomic.Bool{}
+	processedEvents := atomic.Uint64{}
+	seen := make(map[string]int64)
+	mutex := &sync.RWMutex{}
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/api/addEvents",
+		func(req *http.Request) (*http.Response, error) {
+			attempt.Add(1)
+			cer, err := extract(req)
+
+			assert.CmpNoError(err, "Error reading request: %v", err)
+
+			for _, ev := range cer.Events {
+				processedEvents.Add(1)
+				key, found := ev.Attrs["body.str"]
+				assert.True(found)
+				mutex.Lock()
+				sKey := key.(string)
+				_, f := seen[sKey]
+				if !f {
+					seen[sKey] = 0
+				}
+				seen[sKey] += 1
+				mutex.Unlock()
+			}
+
+			wasSuccessful.Store(true)
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				"status":       "success",
+				"bytesCharged": 42,
+			})
+		})
+
+	for bI := 0; bI < MaxBatchCount; bI++ {
+		batch := make([]*add_events.EventBundle, 0)
+		for lI := 0; lI < LogsPerBatch; lI++ {
+			attrs := make(map[string]interface{})
+			attrs["body.str"] = fmt.Sprintf("%04d-%06d", bI, lI)
+			attrs["attributes.p1"] = strings.Repeat("A", rand.Intn(2000))
+
+			event := &add_events.Event{
+				Thread: "5",
+				Sev:    3,
+				Ts:     fmt.Sprintf("%d", time.Now().Nanosecond()),
+				Attrs:  attrs,
+			}
+			eventBundle := &add_events.EventBundle{Event: event, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
+
+			batch = append(batch, eventBundle)
+		}
+
+		assert.Logf("Consuming batch: %d", bI)
+		err := sc.AddEvents(batch)
+		assert.Nil(err)
+
+		time.Sleep(time.Duration(MaxDelayMs*0.7) * time.Millisecond)
+	}
+
+	time.Sleep(time.Second)
+	sc.Finish()
+
+	time.Sleep(2 * time.Second)
+
+	assert.True(wasSuccessful.Load())
+
+	assert.Cmp(processedEvents.Load(), ExpectedLogs, "processed items")
+	assert.Cmp(uint64(len(seen)), ExpectedLogs, "unique items")
+}

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -22,10 +22,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"math/rand"
 	"net/http"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -531,94 +529,4 @@ func (s *SuiteAddEvents) TestAddEventsWithBufferSweeper(assert, require *td.T) {
 	assert.Gte(attempt.Load(), int32(4))
 	info := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": int(attempt.Load())})
-}
-
-func (s *SuiteAddEvents) TestAddEventsManyLogsShouldSucceed(assert, require *td.T) {
-	const MaxDelayMs = 200
-	config := &config.DataSetConfig{
-		Endpoint:       "https://example.com",
-		Tokens:         config.DataSetTokens{WriteLog: "AAAA"},
-		MaxPayloadB:    1000,
-		MaxBufferDelay: time.Duration(MaxDelayMs) * time.Millisecond,
-		RetryBase:      RetryBase,
-	}
-	sc, _ := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
-
-	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
-	sc.SessionInfo = sessionInfo
-
-	const MaxBatchCount = 20
-	const LogsPerBatch = 10000
-	const ExpectedLogs = uint64(MaxBatchCount * LogsPerBatch)
-
-	attempt := atomic.Uint64{}
-	wasSuccessful := atomic.Bool{}
-	processedEvents := atomic.Uint64{}
-	seen := make(map[string]int64)
-	mutex := &sync.RWMutex{}
-
-	httpmock.RegisterResponder(
-		"POST",
-		"https://example.com/api/addEvents",
-		func(req *http.Request) (*http.Response, error) {
-			attempt.Add(1)
-			cer, err := extract(req)
-
-			assert.CmpNoError(err, "Error reading request: %v", err)
-
-			for _, ev := range cer.Events {
-				processedEvents.Add(1)
-				key, found := ev.Attrs["body.str"]
-				assert.True(found)
-				mutex.Lock()
-				sKey := key.(string)
-				_, f := seen[sKey]
-				if !f {
-					seen[sKey] = 0
-				}
-				seen[sKey] += 1
-				mutex.Unlock()
-			}
-
-			wasSuccessful.Store(true)
-			return httpmock.NewJsonResponse(200, map[string]interface{}{
-				"status":       "success",
-				"bytesCharged": 42,
-			})
-		})
-
-	for bI := 0; bI < MaxBatchCount; bI++ {
-		batch := make([]*add_events.EventBundle, 0)
-		for lI := 0; lI < LogsPerBatch; lI++ {
-			attrs := make(map[string]interface{})
-			attrs["body.str"] = fmt.Sprintf("%04d-%06d", bI, lI)
-			attrs["attributes.p1"] = strings.Repeat("A", rand.Intn(2000))
-
-			event := &add_events.Event{
-				Thread: "5",
-				Sev:    3,
-				Ts:     fmt.Sprintf("%d", time.Now().Nanosecond()),
-				Attrs:  attrs,
-			}
-			eventBundle := &add_events.EventBundle{Event: event, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
-
-			batch = append(batch, eventBundle)
-		}
-
-		assert.Logf("Consuming batch: %d", bI)
-		err := sc.AddEvents(batch)
-		assert.Nil(err)
-
-		time.Sleep(time.Duration(MaxDelayMs*0.7) * time.Millisecond)
-	}
-
-	time.Sleep(time.Second)
-	sc.Finish()
-
-	time.Sleep(2 * time.Second)
-
-	assert.True(wasSuccessful.Load())
-
-	assert.Cmp(processedEvents.Load(), ExpectedLogs, "processed items")
-	assert.Cmp(uint64(len(seen)), ExpectedLogs, "unique items")
 }

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -22,8 +22,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -529,4 +531,94 @@ func (s *SuiteAddEvents) TestAddEventsWithBufferSweeper(assert, require *td.T) {
 	assert.Gte(attempt.Load(), int32(4))
 	info := httpmock.GetCallCountInfo()
 	assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": int(attempt.Load())})
+}
+
+func (s *SuiteAddEvents) TestAddEventsManyLogsShouldSucceed(assert, require *td.T) {
+	const MaxDelayMs = 200
+	config := &config.DataSetConfig{
+		Endpoint:       "https://example.com",
+		Tokens:         config.DataSetTokens{WriteLog: "AAAA"},
+		MaxPayloadB:    1000,
+		MaxBufferDelay: time.Duration(MaxDelayMs) * time.Millisecond,
+		RetryBase:      RetryBase,
+	}
+	sc, _ := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+
+	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
+	sc.SessionInfo = sessionInfo
+
+	const MaxBatchCount = 20
+	const LogsPerBatch = 10000
+	const ExpectedLogs = uint64(MaxBatchCount * LogsPerBatch)
+
+	attempt := atomic.Uint64{}
+	wasSuccessful := atomic.Bool{}
+	processedEvents := atomic.Uint64{}
+	seen := make(map[string]int64)
+	mutex := &sync.RWMutex{}
+
+	httpmock.RegisterResponder(
+		"POST",
+		"https://example.com/api/addEvents",
+		func(req *http.Request) (*http.Response, error) {
+			attempt.Add(1)
+			cer, err := extract(req)
+
+			assert.CmpNoError(err, "Error reading request: %v", err)
+
+			for _, ev := range cer.Events {
+				processedEvents.Add(1)
+				key, found := ev.Attrs["body.str"]
+				assert.True(found)
+				mutex.Lock()
+				sKey := key.(string)
+				_, f := seen[sKey]
+				if !f {
+					seen[sKey] = 0
+				}
+				seen[sKey] += 1
+				mutex.Unlock()
+			}
+
+			wasSuccessful.Store(true)
+			return httpmock.NewJsonResponse(200, map[string]interface{}{
+				"status":       "success",
+				"bytesCharged": 42,
+			})
+		})
+
+	for bI := 0; bI < MaxBatchCount; bI++ {
+		batch := make([]*add_events.EventBundle, 0)
+		for lI := 0; lI < LogsPerBatch; lI++ {
+			attrs := make(map[string]interface{})
+			attrs["body.str"] = fmt.Sprintf("%04d-%06d", bI, lI)
+			attrs["attributes.p1"] = strings.Repeat("A", rand.Intn(2000))
+
+			event := &add_events.Event{
+				Thread: "5",
+				Sev:    3,
+				Ts:     fmt.Sprintf("%d", time.Now().Nanosecond()),
+				Attrs:  attrs,
+			}
+			eventBundle := &add_events.EventBundle{Event: event, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
+
+			batch = append(batch, eventBundle)
+		}
+
+		assert.Logf("Consuming batch: %d", bI)
+		err := sc.AddEvents(batch)
+		assert.Nil(err)
+
+		time.Sleep(time.Duration(MaxDelayMs*0.7) * time.Millisecond)
+	}
+
+	time.Sleep(time.Second)
+	sc.Finish()
+
+	time.Sleep(2 * time.Second)
+
+	assert.True(wasSuccessful.Load())
+
+	assert.Cmp(processedEvents.Load(), ExpectedLogs, "processed items")
+	assert.Cmp(uint64(len(seen)), ExpectedLogs, "unique items")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -329,7 +329,6 @@ func (client *DataSetClient) PublishBuffer(buf *buffer.Buffer) {
 
 	// we are manipulating with client.buffer, so lets lock it
 	client.buffersMutex.Lock()
-	defer client.buffersMutex.Unlock()
 	originalStatus := buf.Status()
 	buf.SetStatus(buffer.Publishing)
 
@@ -346,6 +345,8 @@ func (client *DataSetClient) PublishBuffer(buf *buffer.Buffer) {
 		client.initBuffer(newBuf, buf.SessionInfo())
 		client.buffer[buf.Session] = newBuf
 	}
+
+	client.buffersMutex.Unlock()
 	client.Logger.Debug("publishing buffer", buf.ZapStats()...)
 
 	// publish buffer so it can be sent

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.0.3"
-	ReleasedDate = "2023-04-14"
+	Version      = "0.0.4"
+	ReleasedDate = "2023-05-03"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.0.3", Version)
-	assert.Equal(t, "2023-04-14", ReleasedDate)
+	assert.Equal(t, "0.0.4", Version)
+	assert.Equal(t, "2023-05-03", ReleasedDate)
 }


### PR DESCRIPTION
# 🥅 Goal

When many events are pushed through the collector, sometimes more and sometimes less events then expected is received. Lets figure out why.

# 🛠️ Solution

Add unit test, that creates many batches and sends them to the server. Check that each event was processed once.
There are also following changes:
* buffer sweeper is skipping buffers that are receiving events and marks them for immediate publishing
* I have added more comments to make it clearer
* 

# 🏫 Testing

When I run: `make test-many-times COUNT=30` - it always succeeds.

I have added also identical code into datasetexporter code, but there it always shows data race somewhere. Also less than 20 items out of 200k gets lost:
```
        logs_exporter_e2e_test.go:274: Failed test 'processed items'
            DATA: values differ
                     got: (uint64) 199984
                expected: (uint64) 200000
        logs_exporter_e2e_test.go:275: Failed test 'unique items'
            DATA: values differ
                     got: (uint64) 199984
                expected: (uint64) 200000
        logs_exporter_e2e_test.go:276: Failed test
            DATA: comparing map
                Missing 16 keys: ("0000-005134",
                                  "0000-006467",
                                  "0000-007279",
                                  "0000-007705",
                                  "0000-009224",
                                  "0001-000338",
                                  "0001-000553",
                                  "0001-001412",
                                  "0002-001121",
                                  "0002-001474",
                                  "0002-001513",
                                  "0003-000017",
                                  "0007-001613",
                                  "0007-001829",
                                  "0007-004471",
                                  "0008-000616")
```
