### PR TITLE
DSET-1556: Run AddEvents one at a time

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.0.5 Quick Hack
+
+* OpenTelemetry can call AddEvents multiple times in parallel. Add lock so only one of them is in progress in any given time.
+
 ## 0.0.4 Fix Concurrency Issues
 
 * sometimes not all events have been delivered exactly once

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -52,6 +52,8 @@ func (client *DataSetClient) AddEvents(bundles []*add_events.EventBundle) error 
 
 	grouped := client.groupBundles(bundles)
 
+	client.addEventsMutex.Lock()
+	defer client.addEventsMutex.Unlock()
 	for key, bundles := range grouped {
 		client.addBundle(key, bundles)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -63,6 +63,7 @@ type DataSetClient struct {
 	retryAfterMu     sync.RWMutex
 	finished         atomic.Bool
 	Logger           *zap.Logger
+	addEventsMutex   sync.Mutex
 }
 
 func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logger) (*DataSetClient, error) {
@@ -111,6 +112,7 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 		lastErrorMu:      sync.RWMutex{},
 		Logger:           logger,
 		finished:         atomic.Bool{},
+		addEventsMutex:   sync.Mutex{},
 	}
 
 	if cfg.MaxBufferDelay > 0 {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.0.4"
-	ReleasedDate = "2023-05-03"
+	Version      = "0.0.5"
+	ReleasedDate = "2023-05-05"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.0.4", Version)
-	assert.Equal(t, "2023-05-03", ReleasedDate)
+	assert.Equal(t, "0.0.5", Version)
+	assert.Equal(t, "2023-05-05", ReleasedDate)
 }


### PR DESCRIPTION
# 🥅 Goal

When many events are pushed through the collector, sometimes more and sometimes less events then expected is received. Lets figure out why.

# 🛠️ Solution

Although I was trying to solve in the #12 and #13, I was not successful. The problem is that function `AddEvents` could be called multiple times in parallel. I was not expecting this. Current implementation is not able to deal with it, so let's add Lock to make sure that it's called only once.

There are many ways how it can be solved, but it's not clear which one is the best. So lets for now, just allow single call at once - and solve It properly after the long weekend.

# 🏫 Testing

When I run: `make test-many-times COUNT=30` - it always succeeds.
I have added identical code into `datasetexporter` and it passes there as well.