### PR TITLE
DSET-1556: Run integration tests fewer times

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -84,7 +84,8 @@ jobs:
         if: github.ref_name == 'main'
         run: |
           set -e;
-          for i in `seq 1 30`; do
-            echo "Running test ${i} / 50";
+          N=10;
+          for i in `seq 1 ${N}`; do
+            echo "Running test ${i} / ${N}";
             make test;
           done;


### PR DESCRIPTION
Let's run integration tests fewer times. There is no need to wait 50 minutes to get results.