### PR TITLE
DSET-3833: Handle parallel calls of AddEvents

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.0.6 Fix Concurency Issues
+
+* OpenTelemetry can call AddEvents multiple times in parallel. Lets use another Pub/Sub to publish events into topic and then consume them independently.
+
 ## 0.0.5 Quick Hack
 
 * OpenTelemetry can call AddEvents multiple times in parallel. Add lock so only one of them is in progress in any given time.

--- a/examples/client/go.sum
+++ b/examples/client/go.sum
@@ -1,3 +1,4 @@
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,14 +12,20 @@ github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxC
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
 github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/maxatome/go-testdeep v1.13.0 h1:EBmRelH7MhMfPvA+0kXAeOeJUXn3mzul5NmvjLDcQZI=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=

--- a/examples/readme/go.sum
+++ b/examples/readme/go.sum
@@ -1,3 +1,4 @@
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/cskr/pubsub v1.0.2 h1:vlOzMhl6PFn60gRlTQQsIfVwaPB/B/8MziK8FhEPt/0=
 github.com/cskr/pubsub v1.0.2/go.mod h1:/8MzYXk/NJAz782G8RPkFzXTZVu63VotefPnR9TIRis=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -11,14 +12,20 @@ github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxC
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
 github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/maxatome/go-testdeep v1.13.0 h1:EBmRelH7MhMfPvA+0kXAeOeJUXn3mzul5NmvjLDcQZI=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
 go.uber.org/multierr v1.6.0 h1:y6IPFStTAIT5Ytl7/XYmHvzXQ7S3g/IeZW9hyZ5thw4=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/scalyr/dataset-go/pkg/api/response"
@@ -91,14 +90,14 @@ func (client *DataSetClient) newChannelForEvents(key string) {
 }
 
 func (client *DataSetClient) newBufferForEvents(key string) {
-	client.buffersAllMutex.Lock()
-	defer client.buffersAllMutex.Unlock()
-
 	session := fmt.Sprintf("%s-%s", client.Id, key)
-	client.buffersMutex[session] = &sync.Mutex{}
 	buf := buffer.NewEmptyBuffer(session, client.Config.Tokens.WriteLog)
 	client.initBuffer(buf, client.SessionInfo)
+
+	client.buffersAllMutex.Lock()
 	client.buffer[session] = buf
+	defer client.buffersAllMutex.Unlock()
+
 	// create subscriber, so all the upcoming buffers are processed as well
 	client.addEventsSubscriber(session)
 }

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -200,6 +200,7 @@ func (s *SuiteAddEvents) TestAddEventsRetryAfterSec(assert, require *td.T) {
 	event1 := &add_events.Event{Thread: "5", Sev: 3, Ts: "0", Attrs: map[string]interface{}{"message": "test - 1"}}
 	eventBundle1 := &add_events.EventBundle{Event: event1, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
 	err1 := sc.AddEvents([]*add_events.EventBundle{eventBundle1})
+	time.Sleep(RetryBase)
 	sc.SendAllAddEventsBuffers()
 
 	// wait for processing
@@ -207,7 +208,7 @@ func (s *SuiteAddEvents) TestAddEventsRetryAfterSec(assert, require *td.T) {
 		if wasSuccessful.Load() {
 			break
 		}
-		time.Sleep(time.Second)
+		time.Sleep(RetryBase)
 	}
 
 	assert.True(wasSuccessful.Load())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -46,24 +46,28 @@ func IsRetryableStatus(status uint32) bool {
 }
 
 type DataSetClient struct {
-	Id               uuid.UUID
-	Config           *config.DataSetConfig
-	Client           *http.Client
-	SessionInfo      *add_events.SessionInfo
-	buffer           map[string]*buffer.Buffer
-	buffersEnqueued  atomic.Uint64
-	buffersProcessed atomic.Uint64
-	buffersMutex     sync.Mutex
-	PubSub           *pubsub.PubSub
-	workers          sync.WaitGroup
-	LastHttpStatus   atomic.Uint32
-	lastError        error
-	lastErrorMu      sync.RWMutex
-	retryAfter       time.Time
-	retryAfterMu     sync.RWMutex
-	finished         atomic.Bool
-	Logger           *zap.Logger
-	addEventsMutex   sync.Mutex
+	Id                uuid.UUID
+	Config            *config.DataSetConfig
+	Client            *http.Client
+	SessionInfo       *add_events.SessionInfo
+	buffer            map[string]*buffer.Buffer
+	buffersMutex      map[string]*sync.Mutex
+	buffersEnqueued   atomic.Uint64
+	buffersProcessed  atomic.Uint64
+	BuffersPubSub     *pubsub.PubSub
+	workers           sync.WaitGroup
+	LastHttpStatus    atomic.Uint32
+	lastError         error
+	lastErrorMu       sync.RWMutex
+	retryAfter        time.Time
+	retryAfterMu      sync.RWMutex
+	finished          atomic.Bool
+	Logger            *zap.Logger
+	eventsEnqueued    atomic.Uint64
+	eventsProcessed   atomic.Uint64
+	addEventsMutex    sync.Mutex
+	addEventsPubSub   *pubsub.PubSub
+	addEventsChannels map[string]chan interface{}
 }
 
 func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logger) (*DataSetClient, error) {
@@ -97,22 +101,26 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 		return nil, fmt.Errorf("it was not possible to generate UUID: %w", err)
 	}
 	dataClient := &DataSetClient{
-		Id:               id,
-		Config:           cfg,
-		Client:           client,
-		buffer:           make(map[string]*buffer.Buffer),
-		buffersEnqueued:  atomic.Uint64{},
-		buffersProcessed: atomic.Uint64{},
-		buffersMutex:     sync.Mutex{},
-		PubSub:           pubsub.New(0),
-		workers:          sync.WaitGroup{},
-		LastHttpStatus:   atomic.Uint32{},
-		retryAfter:       time.Now(),
-		retryAfterMu:     sync.RWMutex{},
-		lastErrorMu:      sync.RWMutex{},
-		Logger:           logger,
-		finished:         atomic.Bool{},
-		addEventsMutex:   sync.Mutex{},
+		Id:                id,
+		Config:            cfg,
+		Client:            client,
+		buffer:            make(map[string]*buffer.Buffer),
+		buffersEnqueued:   atomic.Uint64{},
+		buffersProcessed:  atomic.Uint64{},
+		buffersMutex:      make(map[string]*sync.Mutex),
+		BuffersPubSub:     pubsub.New(0),
+		workers:           sync.WaitGroup{},
+		LastHttpStatus:    atomic.Uint32{},
+		retryAfter:        time.Now(),
+		retryAfterMu:      sync.RWMutex{},
+		lastErrorMu:       sync.RWMutex{},
+		Logger:            logger,
+		finished:          atomic.Bool{},
+		eventsEnqueued:    atomic.Uint64{},
+		eventsProcessed:   atomic.Uint64{},
+		addEventsMutex:    sync.Mutex{},
+		addEventsPubSub:   pubsub.New(0),
+		addEventsChannels: make(map[string]chan interface{}),
 	}
 
 	if cfg.MaxBufferDelay > 0 {
@@ -139,25 +147,11 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 	return dataClient, nil
 }
 
-func (client *DataSetClient) Buffer(key string, info *add_events.SessionInfo) *buffer.Buffer {
+func (client *DataSetClient) Buffer(key string) *buffer.Buffer {
 	session := fmt.Sprintf("%s-%s", client.Id, key)
-	// lock client.buffer so we can manipulate it safely
-	client.buffersMutex.Lock()
-	defer client.buffersMutex.Unlock()
-
-	// find the buffer
-	buf, found := client.buffer[session]
-	if !found {
-		// if it's not there, initialize it
-		buf = buffer.NewEmptyBuffer(session, client.Config.Tokens.WriteLog)
-		client.initBuffer(buf, info)
-		client.buffer[session] = buf
-
-		// create subscriber, so all the upcoming buffers are processed as well
-		client.AddEventsSubscriber(session)
-	}
-
-	return buf
+	client.buffersMutex[session].Lock()
+	defer client.buffersMutex[session].Unlock()
+	return client.buffer[session]
 }
 
 func (client *DataSetClient) initBuffer(buff *buffer.Buffer, info *add_events.SessionInfo) {
@@ -180,7 +174,7 @@ func (client *DataSetClient) initBuffer(buff *buffer.Buffer, info *add_events.Se
 }
 
 func (client *DataSetClient) AddEventsSubscriber(session string) {
-	ch := client.PubSub.Sub(session)
+	ch := client.BuffersPubSub.Sub(session)
 	go (func(session string, ch chan interface{}) {
 		client.ListenAndSendBufferForSession(session, ch)
 	})(session, ch)
@@ -286,10 +280,10 @@ func (client *DataSetClient) bufferSweeper(delay time.Duration) {
 	client.Logger.Info("Starting buffer sweeper with delay", zap.Duration("delay", delay))
 	for i := uint64(0); ; i++ {
 		// if everything was finished, there is no need to run buffer sweeper
-		if client.finished.Load() {
-			client.Logger.Info("Stopping buffer sweeper", zap.Uint64("sweepId", i))
-			break
-		}
+		//if client.finished.Load() {
+		//	client.Logger.Info("Stopping buffer sweeper", zap.Uint64("sweepId", i))
+		//	break
+		//}
 		kept := atomic.Uint64{}
 		swept := atomic.Uint64{}
 		client.Logger.Debug("Buffer sweeping started", zap.Uint64("sweepId", i))
@@ -337,7 +331,7 @@ func (client *DataSetClient) PublishBuffer(buf *buffer.Buffer) {
 	}
 
 	// we are manipulating with client.buffer, so lets lock it
-	client.buffersMutex.Lock()
+	client.buffersMutex[buf.Session].Lock()
 	originalStatus := buf.Status()
 	buf.SetStatus(buffer.Publishing)
 
@@ -355,12 +349,12 @@ func (client *DataSetClient) PublishBuffer(buf *buffer.Buffer) {
 		client.buffer[buf.Session] = newBuf
 	}
 
-	client.buffersMutex.Unlock()
+	client.buffersMutex[buf.Session].Unlock()
 	client.Logger.Debug("publishing buffer", buf.ZapStats()...)
 
 	// publish buffer so it can be sent
 	client.buffersEnqueued.Add(+1)
-	client.PubSub.Pub(buf, buf.Session)
+	client.BuffersPubSub.Pub(buf, buf.Session)
 }
 
 func (client *DataSetClient) shouldRejectNextBatch() error {

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -86,6 +86,7 @@ func (s *SuiteClient) TestClientBuffer(assert, require *td.T) {
 		ServerId:   "serverId",
 		ServerType: "testing",
 	}
+	sc.SessionInfo = &sessionInfo
 
 	event1 := &add_events.Event{
 		Thread: "TId",
@@ -97,7 +98,8 @@ func (s *SuiteClient) TestClientBuffer(assert, require *td.T) {
 		},
 	}
 
-	buffer1 := sc.Buffer("aaa", &sessionInfo)
+	sc.newBufferForEvents("aaa")
+	buffer1 := sc.Buffer("aaa")
 	added, err := buffer1.AddBundle(&add_events.EventBundle{Event: event1})
 	assert.Nil(err)
 	assert.Cmp(added, buffer.Added)
@@ -119,7 +121,7 @@ func (s *SuiteClient) TestClientBuffer(assert, require *td.T) {
 	}
 
 	sc.PublishBuffer(buffer1)
-	buffer2 := sc.Buffer("aaa", &sessionInfo)
+	buffer2 := sc.Buffer("aaa")
 	added2, err := buffer2.AddBundle(&add_events.EventBundle{Event: event2})
 	assert.Nil(err)
 	assert.Cmp(added2, buffer.Added)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -99,7 +99,7 @@ func (s *SuiteClient) TestClientBuffer(assert, require *td.T) {
 	}
 
 	sc.newBufferForEvents("aaa")
-	buffer1 := sc.Buffer("aaa")
+	buffer1 := sc.getBuffer("aaa")
 	added, err := buffer1.AddBundle(&add_events.EventBundle{Event: event1})
 	assert.Nil(err)
 	assert.Cmp(added, buffer.Added)
@@ -120,8 +120,8 @@ func (s *SuiteClient) TestClientBuffer(assert, require *td.T) {
 		},
 	}
 
-	sc.PublishBuffer(buffer1)
-	buffer2 := sc.Buffer("aaa")
+	sc.publishBuffer(buffer1)
+	buffer2 := sc.getBuffer("aaa")
 	added2, err := buffer2.AddBundle(&add_events.EventBundle{Event: event2})
 	assert.Nil(err)
 	assert.Cmp(added2, buffer.Added)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.0.5"
-	ReleasedDate = "2023-05-05"
+	Version      = "0.0.6"
+	ReleasedDate = "2023-05-10"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.0.5", Version)
-	assert.Equal(t, "2023-05-05", ReleasedDate)
+	assert.Equal(t, "0.0.6", Version)
+	assert.Equal(t, "2023-05-10", ReleasedDate)
 }


### PR DESCRIPTION
# 🥅 Goal

In the PR #14 I have added one global mutex that allowed only single call of `AddEvents` function at once. In this PR make it more granular.

# 🛠️ Solution


Although I was trying to solve in the #12 and #13, I was not successful. I have quick solved it in #14. This PR contains more proper fix. Idea is to introduce another queue. The current logic is:

* Add each event into topic based on the key
* For each topic there is subscriber that reads those messages. 
* Read messages are added into buffer. Once the buffer is full add into into different pub/sub where topic is key
* For each topic there is subscriber, that reads those buffers and calls API to publish them

# 🏫 Testing

When I run: `make test-many-times COUNT=30` - it always succeeds.
I have added identical code into `datasetexporter` and it passes there as well.