### PR TITLE
DSET-2106: Fix flaky tests first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test-many-times:
 		grep -H FAIL out-test-$${i}.log; \
 		echo; \
 	done; \
-	echo "Grep for FAIL"; \
+	echo "Grep for FAIL - no lines should be found"; \
 	! grep -H FAIL out-test-*.log;
 
 foo:

--- a/pkg/buffer/buffer_test.go
+++ b/pkg/buffer/buffer_test.go
@@ -227,7 +227,7 @@ func TestAddEventWithShouldSendAge(t *testing.T) {
 				break
 			}
 		}
-		assert.Greater(t, waited, 5)
+		assert.GreaterOrEqual(t, waited, 5)
 		finished.Add(1)
 	}()
 
@@ -266,7 +266,7 @@ func TestAddEventWithShouldSendSize(t *testing.T) {
 				break
 			}
 		}
-		assert.Greater(t, waited, 5)
+		assert.GreaterOrEqual(t, waited, 5)
 		finished.Add(1)
 	}()
 

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -564,9 +564,9 @@ func TestAddEventsWithBufferSweeper(t *testing.T) {
 	}(NumEvents)
 
 	// wait on all buffers to be sent
-	time.Sleep(sentDelay * NumEvents * 2)
+	time.Sleep(sentDelay * (NumEvents*2 + 1))
 
-	assert.Greater(t, attempt.Load(), int32(4))
+	assert.GreaterOrEqual(t, attempt.Load(), int32(4))
 	// info := httpmock.GetCallCountInfo()
 	// assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": int(attempt.Load())})
 }


### PR DESCRIPTION
# 🥅 Goal

In PR #20 I have switched testing framework. There are still some flaky tests.

# 🛠️ Solution

Fix flaky tests. It looks that the issue is with tests depends on timing and GitHub is slower, so some number of retries is different.

# 🏫 Testing

* When I run: `make test-many-times COUNT=10` - it always succeeds.