### PR TITLE
DSET-2201: Rertry on 401 and 403 as well

### DIFF
--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -577,6 +577,7 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		attempt.Add(1)
 
+		w.WriteHeader(503)
 		payload, err := json.Marshal(map[string]interface{}{
 			"status":       "success",
 			"bytesCharged": 42,
@@ -612,7 +613,7 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	assert.Nil(t, err)
 	err = sc.Finish()
 
-	assert.Nil(t, err)
-	// info := httpmock.GetCallCountInfo()
-	// assert.Gte(info["POST https://example.com/api/addEvents"], 3)
+	assert.NotNil(t, err)
+	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")
+	assert.GreaterOrEqual(t, attempt.Load(), int32(2))
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -43,10 +43,12 @@ const (
 	HttpErrorHasErrorMessage = 499
 )
 
-func isOkStatus(status uint32) bool {
+// IsOkStatus returns true if status code is 200, false otherwise.
+func IsOkStatus(status uint32) bool {
 	return status == http.StatusOK
 }
 
+// IsRetryableStatus returns true if status code is 401, 403, 429, or any 5xx, false otherwise.
 func IsRetryableStatus(status uint32) bool {
 	return status == http.StatusUnauthorized || status == http.StatusForbidden || status == http.StatusTooManyRequests || status >= http.StatusInternalServerError
 }
@@ -246,7 +248,7 @@ func (client *DataSetClient) listenAndSendBufferForSession(session string, ch ch
 						zaps...,
 					)
 
-					if isOkStatus(lastHttpStatus) {
+					if IsOkStatus(lastHttpStatus) {
 						// everything was fine, there is no need for retries
 						break
 					}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -122,3 +122,69 @@ func TestClientBuffer(t *testing.T) {
 	assert.Equal(t, (params1.Events)[0].Ts, "1")
 	assert.Equal(t, (params2.Events)[0].Ts, "2")
 }
+
+func TestHttpStatusCodes(t *testing.T) {
+	tests := []struct {
+		statusCode  uint32
+		isOk        bool
+		isRetryable bool
+	}{
+		// 200
+		{
+			statusCode:  http.StatusOK,
+			isOk:        true,
+			isRetryable: false,
+		},
+		{
+			statusCode:  http.StatusCreated,
+			isOk:        false,
+			isRetryable: false,
+		},
+		{
+			statusCode:  http.StatusAccepted,
+			isOk:        false,
+			isRetryable: false,
+		},
+		// 300
+		{
+			statusCode:  http.StatusMovedPermanently,
+			isOk:        false,
+			isRetryable: false,
+		},
+		// 400
+		{
+			statusCode:  http.StatusUnauthorized,
+			isOk:        false,
+			isRetryable: true,
+		},
+		{
+			statusCode:  http.StatusForbidden,
+			isOk:        false,
+			isRetryable: true,
+		},
+		{
+			statusCode:  http.StatusTooManyRequests,
+			isOk:        false,
+			isRetryable: true,
+		},
+		// 500
+		{
+			statusCode:  http.StatusInternalServerError,
+			isOk:        false,
+			isRetryable: true,
+		},
+		{
+			statusCode:  http.StatusNotImplemented,
+			isOk:        false,
+			isRetryable: true,
+		},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("HTTP Status code: %d", tt.statusCode)
+		t.Run(name, func(*testing.T) {
+			assert.Equal(t, tt.isOk, IsOkStatus(tt.statusCode), name)
+			assert.Equal(t, tt.isRetryable, IsRetryableStatus(tt.statusCode), name)
+		})
+	}
+}


### PR DESCRIPTION
# 🥅 Goal

Retry when server returns 401 or 403 to handle situation when there is some glitch in authentication.

# 🛠️ Solution

This was already implemented, so I have just added some tests to make sure that expected status codes are there as well. 

# 🏫 Testing

* When I run: `make test-many-times COUNT=10` - it always succeeds.