### PR TITLE
DSET-3951: Log statistics more often with duration as well

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -332,6 +332,11 @@ func (client *DataSetClient) logStatistics() {
 	processingDur := lastAt.Sub(firstAt)
 	processingInSec := processingDur.Seconds()
 
+	// if nothing was processed, do not log statistics
+	if processingInSec <= 0 {
+		return
+	}
+
 	// log buffer stats
 	bProcessed := client.buffersProcessed.Load()
 	bEnqueued := client.buffersEnqueued.Load()


### PR DESCRIPTION
# 🥅 Goal

Log statistics more often and include also duration in seconds.

# 🛠️ Solution

To be able to benchmark it, we should now for how long it's running and whether all the expected events were processed. To be able to do that, we have to log statistics more often and include more information.

# 🏫 Testing

Same as PR #27 