### PR TITLE
[DSET-4072] Include (truncated) response body in the error message in case we fail to parse the response body

### DIFF
--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -392,7 +392,7 @@ func (client *DataSetClient) apiCall(req *http.Request, response response.SetRes
 
 	err = json.Unmarshal(responseBody, &response)
 	if err != nil {
-		return fmt.Errorf("unable to parse response body: %w, url: %s, response: %s", err, client.addEventsEndpointUrl, truncateText(string(responseBody), 500))
+		return fmt.Errorf("unable to parse response body: %w, url: %s, response: %s", err, client.addEventsEndpointUrl, truncateText(string(responseBody), 1000))
 	}
 
 	response.SetResponseObj(resp)

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -392,7 +392,7 @@ func (client *DataSetClient) apiCall(req *http.Request, response response.SetRes
 
 	err = json.Unmarshal(responseBody, &response)
 	if err != nil {
-		return fmt.Errorf("unable to parse response body: %w", err)
+		return fmt.Errorf("unable to parse response body: %w, response: %s", err, truncateText(string(responseBody), 1000))
 	}
 
 	response.SetResponseObj(resp)
@@ -416,4 +416,13 @@ func (client *DataSetClient) getBuffers() []*buffer.Buffer {
 		buffers = append(buffers, buf)
 	}
 	return buffers
+}
+
+// Truncate provided text to the provided length
+func truncateText(text string, length int) string {
+	if len(text) > length {
+		text = string([]byte(text)[:length]) + "..."
+	}
+
+	return text
 }

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -320,7 +320,7 @@ func (client *DataSetClient) SendAddEventsBuffer(buf *buffer.Buffer) (*add_event
 	resp := &add_events.AddEventsResponse{}
 
 	httpRequest, err := request.NewRequest(
-		"POST", client.Config.Endpoint+"/api/addEvents",
+		"POST", client.addEventsEndpointUrl,
 	).WithWriteLog(client.Config.Tokens).RawRequest(payload).HttpRequest()
 	if err != nil {
 		return nil, len(payload), fmt.Errorf("cannot create request: %w", err)
@@ -392,7 +392,7 @@ func (client *DataSetClient) apiCall(req *http.Request, response response.SetRes
 
 	err = json.Unmarshal(responseBody, &response)
 	if err != nil {
-		return fmt.Errorf("unable to parse response body: %w, response: %s", err, truncateText(string(responseBody), 1000))
+		return fmt.Errorf("unable to parse response body: %w, url: %s, response: %s", err, client.addEventsEndpointUrl, truncateText(string(responseBody), 500))
 	}
 
 	response.SetResponseObj(resp)

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -656,6 +656,8 @@ func TestAddEventsLogResponseBodyOnInvalidJson(t *testing.T) {
 	assert.Nil(t, err)
 	err = sc.Finish()
 
+	// TODO: Figure out how to assert on the message logged by the client (may be easiest to test apiCall() directly.
+
 	assert.NotNil(t, err)
 	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")
 	assert.GreaterOrEqual(t, attempt.Load(), int32(0))

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -617,3 +617,46 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")
 	assert.GreaterOrEqual(t, attempt.Load(), int32(2))
 }
+
+func TestAddEventsLogResponseBodyOnInvalidJson(t *testing.T) {
+	attempt := atomic.Int32{}
+	attempt.Store(0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		attempt.Add(1)
+
+		w.WriteHeader(503)
+		payload := []byte("<html>not valid json</html>")
+		l, err := w.Write(payload)
+		assert.Greater(t, l, 1)
+		assert.NoError(t, err)
+	}))
+	defer server.Close()
+
+	config := &config.DataSetConfig{
+		Endpoint: server.URL,
+		Tokens:   config.DataSetTokens{WriteLog: "AAAA"},
+		BufferSettings: buffer_config.DataSetBufferSettings{
+			MaxSize:                  20,
+			MaxLifetime:              0,
+			RetryInitialInterval:     time.Second,
+			RetryMaxInterval:         time.Second,
+			RetryMaxElapsedTime:      1 * time.Second,
+			RetryMultiplier:          1.0,
+			RetryRandomizationFactor: 1.0,
+		},
+	}
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	require.Nil(t, err)
+
+	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
+	sc.SessionInfo = sessionInfo
+	event1 := &add_events.Event{Thread: "5", Sev: 3, Ts: "0", Attrs: map[string]interface{}{"message": "test - 1"}}
+	eventBundle1 := &add_events.EventBundle{Event: event1, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
+	err = sc.AddEvents([]*add_events.EventBundle{eventBundle1})
+	assert.Nil(t, err)
+	err = sc.Finish()
+
+	assert.NotNil(t, err)
+	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")
+	assert.GreaterOrEqual(t, attempt.Load(), int32(0))
+}

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -640,7 +640,7 @@ func TestAddEventsLogResponseBodyOnInvalidJson(t *testing.T) {
 			MaxLifetime:              0,
 			RetryInitialInterval:     time.Second,
 			RetryMaxInterval:         time.Second,
-			RetryMaxElapsedTime:      1 * time.Second,
+			RetryMaxElapsedTime:      3 * time.Second,
 			RetryMultiplier:          1.0,
 			RetryRandomizationFactor: 1.0,
 		},
@@ -656,7 +656,10 @@ func TestAddEventsLogResponseBodyOnInvalidJson(t *testing.T) {
 	assert.Nil(t, err)
 	err = sc.Finish()
 
-	// TODO: Figure out how to assert on the message logged by the client (may be easiest to test apiCall() directly.
+	lastError := sc.LastError()
+
+	assert.NotNil(t, lastError)
+	assert.Equal(t, fmt.Errorf("unable to parse response body: invalid character '<' looking for beginning of value, url: %s, response: <html>not valid json</html>", sc.addEventsEndpointUrl).Error(), lastError.Error())
 
 	assert.NotNil(t, err)
 	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -189,14 +189,16 @@ func TestHttpStatusCodes(t *testing.T) {
 	}
 }
 
-func TestAddEventsEndpointUrlTrailingSlashIsHandledCorrectly(t *testing.T) {
-	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
+func TestAddEventsEndpointUrlWithoutTrailingSlash(t *testing.T) {
+	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com")
 	cfg, err := config.New(config.FromEnv())
 	assert.Nil(t, err)
 	sc, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()))
 	require.Nil(t, err)
 	assert.Equal(t, sc.addEventsEndpointUrl, "https://app.scalyr.com/api/addEvents")
+}
 
+func TestAddEventsEndpointUrlWithTrailingSlash(t *testing.T) {
 	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
 	cfg2, err := config.New(config.FromEnv())
 	assert.Nil(t, err)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -188,3 +188,19 @@ func TestHttpStatusCodes(t *testing.T) {
 		})
 	}
 }
+
+func TestAddEventsEndpointUrlTrailingSlashIsHandledCorrectly(t *testing.T) {
+	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
+	cfg, err := config.New(config.FromEnv())
+	assert.Nil(t, err)
+	sc, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()))
+	require.Nil(t, err)
+	assert.Equal(t, sc.addEventsEndpointUrl, "https://app.scalyr.com/api/addEvents")
+
+	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
+	cfg2, err := config.New(config.FromEnv())
+	assert.Nil(t, err)
+	sc2, err := NewClient(cfg2, nil, zap.Must(zap.NewDevelopment()))
+	require.Nil(t, err)
+	assert.Equal(t, sc2.addEventsEndpointUrl, "https://app.scalyr.com/api/addEvents")
+}


### PR DESCRIPTION
This pull request updates ``apiCall()`` function to also log partial raw response body in case we fail to parse response body as JSON.

This will help troubleshooting various edge cases when the API doesn't return valid JSON.