### PR TITLE
DSET-3467 feature: add more details to User-Agent header

### DIFF
--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -52,11 +52,14 @@ func main() {
 		panic(err)
 	}
 
+	libraryConsumerUserAgentSuffix := "OtelCollector;1.2.3"
+
 	// build client
 	cl, err := client.NewClient(
 		cfg,
 		&http.Client{},
 		zap.Must(zap.NewDevelopment()),
+		&libraryConsumerUserAgentSuffix,
 	)
 	if err != nil {
 		panic(err)

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -76,8 +76,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
+	libraryConsumerUserAgentSuffix := "OtelCollector;1.2.3"
 	// build client
-	cl, err := client.NewClient(cfg, &http.Client{}, logger)
+	cl, err := client.NewClient(cfg, &http.Client{}, logger, &libraryConsumerUserAgentSuffix)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -319,8 +319,8 @@ func (client *DataSetClient) sendAddEventsBuffer(buf *buffer.Buffer) (*add_event
 	resp := &add_events.AddEventsResponse{}
 
 	httpRequest, err := request.NewApiRequest(
-		"POST", client.addEventsEndpointUrl,
-	).WithWriteLog(client.Config.Tokens).RawRequest(payload).HttpRequest()
+		http.MethodPost, client.addEventsEndpointUrl,
+	).WithWriteLog(client.Config.Tokens).WithPayload(payload).WithUserAgent(client.userAgent).HttpRequest()
 	if err != nil {
 		return nil, len(payload), fmt.Errorf("cannot create request: %w", err)
 	}

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -98,7 +98,7 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 			RetryMaxElapsedTime:      10 * RetryBase,
 		},
 	}
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -93,7 +93,7 @@ func TestAddEventsRetry(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -166,7 +166,7 @@ func TestAddEventsRetryAfterSec(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -252,7 +252,7 @@ func TestAddEventsRetryAfterTime(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -341,7 +341,7 @@ func TestAddEventsLargeEvent(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -423,7 +423,7 @@ func TestAddEventsLargeEventThatNeedEscaping(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -447,7 +447,7 @@ func TestAddEventsRejectAfterFinish(t *testing.T) {
 		buffer_config.WithRetryInitialInterval(RetryBase),
 		buffer_config.WithRetryMaxInterval(RetryBase),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 	err = sc.Shutdown()
 	assert.Nil(t, err)
@@ -493,7 +493,7 @@ func TestAddEventsWithBufferSweeper(t *testing.T) {
 			RetryMaxElapsedTime:      10 * RetryBase,
 		},
 	}
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -527,7 +527,7 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	config := newDataSetConfig(server.URL, *newBufferSettings(
 		buffer_config.WithRetryMaxElapsedTime(time.Duration(5) * time.Second),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -550,7 +550,7 @@ func TestAddEventsLogResponseBodyOnInvalidJson(t *testing.T) {
 	config := newDataSetConfig(server.URL, *newBufferSettings(
 		buffer_config.WithRetryMaxElapsedTime(time.Duration(3) * time.Second),
 	))
-	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(config, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -583,7 +583,7 @@ func TestAddEventsAreNotRejectedOncePreviousReqRetriesMaxLifetimeExpired(t *test
 		buffer_config.WithRetryMaxElapsedTime(time.Duration(maxElapsedTime)*time.Second),
 		buffer_config.WithRetryRandomizationFactor(0.000000001),
 	))
-	client, err := NewClient(dataSetConfig, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	client, err := NewClient(dataSetConfig, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}
@@ -614,7 +614,7 @@ func TestAddEventsAreRejectedOncePreviousReqRetriesMaxLifetimeNotExpired(t *test
 		buffer_config.WithRetryMaxElapsedTime(time.Duration(maxElapsedTime)*time.Second),
 		buffer_config.WithRetryRandomizationFactor(0.000000001),
 	))
-	client, err := NewClient(dataSetConfig, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	client, err := NewClient(dataSetConfig, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := &add_events.SessionInfo{ServerId: "a", ServerType: "b"}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -126,7 +126,7 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 
 	userAgent := fmt.Sprintf(
 		"%s;%s;%s;%s;%s;%s;%d",
-		"datasetexporter",
+		"dataset-go",
 		version.Version,
 		version.ReleasedDate,
 		id,

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -219,7 +219,7 @@ func TestUserAgent(t *testing.T) {
 	client, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), &libraryConsumerUserAgentSuffix)
 	clientId := client.Id.String()
 	require.Nil(t, err)
-	assert.Equal(t, client.userAgent, "datasetexporter;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu+";"+libraryConsumerUserAgentSuffix)
+	assert.Equal(t, client.userAgent, "dataset-go;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu+";"+libraryConsumerUserAgentSuffix)
 }
 
 func TestUserAgentWithoutCollectorAttrs(t *testing.T) {
@@ -230,5 +230,5 @@ func TestUserAgentWithoutCollectorAttrs(t *testing.T) {
 	client, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), nil)
 	clientId := client.Id.String()
 	require.Nil(t, err)
-	assert.Equal(t, client.userAgent, "datasetexporter;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu)
+	assert.Equal(t, client.userAgent, "dataset-go;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu)
 }

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -21,7 +21,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"testing"
+
+	"github.com/scalyr/dataset-go/pkg/version"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,7 +45,7 @@ func TestNewClient(t *testing.T) {
 	t.Setenv("SCALYR_READCONFIG_TOKEN", "readconfig")
 	cfg, err := config.New(config.FromEnv())
 	assert.Nil(t, err)
-	sc4, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()))
+	sc4, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 	assert.Equal(t, sc4.Config.Tokens.ReadLog, "readlog")
 	assert.Equal(t, sc4.Config.Tokens.WriteLog, "writelog")
@@ -61,7 +64,7 @@ func TestClientBuffer(t *testing.T) {
 		Endpoint:       ts.URL,
 		Tokens:         config.DataSetTokens{WriteLog: token},
 		BufferSettings: buffer_config.NewDefaultDataSetBufferSettings(),
-	}, &http.Client{}, zap.Must(zap.NewDevelopment()))
+	}, &http.Client{}, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 
 	sessionInfo := add_events.SessionInfo{
@@ -193,7 +196,7 @@ func TestAddEventsEndpointUrlWithoutTrailingSlash(t *testing.T) {
 	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com")
 	cfg, err := config.New(config.FromEnv())
 	assert.Nil(t, err)
-	sc, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()))
+	sc, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 	assert.Equal(t, sc.addEventsEndpointUrl, "https://app.scalyr.com/api/addEvents")
 }
@@ -202,7 +205,30 @@ func TestAddEventsEndpointUrlWithTrailingSlash(t *testing.T) {
 	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
 	cfg2, err := config.New(config.FromEnv())
 	assert.Nil(t, err)
-	sc2, err := NewClient(cfg2, nil, zap.Must(zap.NewDevelopment()))
+	sc2, err := NewClient(cfg2, nil, zap.Must(zap.NewDevelopment()), nil)
 	require.Nil(t, err)
 	assert.Equal(t, sc2.addEventsEndpointUrl, "https://app.scalyr.com/api/addEvents")
+}
+
+func TestUserAgent(t *testing.T) {
+	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
+	libraryConsumerUserAgentSuffix := "OtelCollector;0.80.0;traces"
+	numCpu := fmt.Sprint(runtime.NumCPU())
+	cfg, err := config.New(config.FromEnv())
+	assert.Nil(t, err)
+	client, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), &libraryConsumerUserAgentSuffix)
+	clientId := client.Id.String()
+	require.Nil(t, err)
+	assert.Equal(t, client.userAgent, "datasetexporter;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu+";"+libraryConsumerUserAgentSuffix)
+}
+
+func TestUserAgentWithoutCollectorAttrs(t *testing.T) {
+	t.Setenv("SCALYR_SERVER", "https://app.scalyr.com/")
+	numCpu := fmt.Sprint(runtime.NumCPU())
+	cfg, err := config.New(config.FromEnv())
+	assert.Nil(t, err)
+	client, err := NewClient(cfg, nil, zap.Must(zap.NewDevelopment()), nil)
+	clientId := client.Id.String()
+	require.Nil(t, err)
+	assert.Equal(t, client.userAgent, "datasetexporter;"+version.Version+";"+version.ReleasedDate+";"+clientId+";"+runtime.GOOS+";"+runtime.GOARCH+";"+numCpu)
 }


### PR DESCRIPTION
In order to improve telemetry lets propagate 
- OtelCollector attributes to
- library version
- OS details

to User-Agent header