### PR TITLE
DSET-4002: Release version 0.0.10

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.0.10
+
+* feat: make `serverHost` explicit field of the `Event`.
+
 ## 0.0.9 Add more retry parameters
 
 * fix: recovery from error mode - when DataSet HTTP req sending fails consuming of additional input events is blocked. Fix issue with rejected input events once retry attempts times out.

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.0.9"
-	ReleasedDate = "2023-06-22"
+	Version      = "0.0.10"
+	ReleasedDate = "2023-07-10"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.0.9", Version)
-	assert.Equal(t, "2023-06-22", ReleasedDate)
+	assert.Equal(t, "0.0.10", Version)
+	assert.Equal(t, "2023-07-10", ReleasedDate)
 }


### PR DESCRIPTION
To be able to use #39 from the `datasetexporter` in the [opentelemetry](https://github.com/open-telemetry/opentelemetry-collector-contrib) we have to release new version with higher tag.

So let's release it.