### PR TITLE
DSET-4050: Improve logging related to shutting down the client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ coverage-all:
 build-examples:
 	for d in examples/*; do \
   		echo "Build example: $${d}"; \
-		(cd $${d}; go mod tidy && go build && ls -lrt | tail -n 1); \
+		(cd $${d}; go mod tidy && go build) || exit 1; \
 	done;
 
 .PHONY: test-ssl-certificates

--- a/examples/client/go.sum
+++ b/examples/client/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=

--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -70,9 +70,6 @@ func main() {
 		panic(err)
 	}
 
-	// send all buffers when we want to finish
-	defer cl.SendAllAddEventsBuffers() // TODO use cl.Shutdown() instead
-
 	// build some bundles
 	bundles := make([]*add_events.EventBundle, 0)
 	for i := 0; i < BundleCount; i++ {
@@ -119,5 +116,10 @@ func main() {
 			fmt.Printf("There was problem in batch starting at %d: %v", j, err)
 		}
 		time.Sleep(BatchDelay)
+	}
+
+	shutdownError := cl.Shutdown()
+	if shutdownError != nil {
+		panic(shutdownError)
 	}
 }

--- a/examples/readme/go.sum
+++ b/examples/readme/go.sum
@@ -18,8 +18,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.8.3 h1:RP3t2pwF7cMEbC1dqtB6poj3niw/9gnV4Cjg5oW5gtY=
-github.com/stretchr/testify v1.8.3/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -92,7 +92,7 @@ func main() {
 		panic(err)
 	}
 
-	// send all buffers when we want to finish
+	// Finish event processing
 	err = cl.Shutdown()
 	if err != nil {
 		panic(err)

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -258,7 +258,10 @@ func (client *DataSetClient) Shutdown() error {
 			zap.Uint64("eventsProcessed", client.eventsProcessed.Load()),
 		)
 		if backoffDelay == expBackoff.Stop {
-			lastError = fmt.Errorf("not all events have been processed")
+			lastError = fmt.Errorf(
+				"not all events have been processed - %d",
+				client.eventsEnqueued.Load()-client.eventsProcessed.Load(),
+			)
 			client.Logger.Error(
 				"Shutting down - not all events have been processed",
 				zap.Int("retryNum", retryNum),
@@ -302,7 +305,10 @@ func (client *DataSetClient) Shutdown() error {
 			zap.Uint64("buffersDropped", client.buffersDropped.Load()),
 		)
 		if backoffDelay == expBackoff.Stop {
-			lastError = fmt.Errorf("not all buffers have been processed")
+			lastError = fmt.Errorf(
+				"not all buffers have been processed - %d",
+				client.buffersEnqueued.Load()-client.buffersProcessed.Load()-client.buffersDropped.Load(),
+			)
 			client.Logger.Error(
 				"Shutting down - not all buffers have been processed",
 				zap.Int("retryNum", retryNum),

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -42,7 +42,7 @@ import (
 )
 
 func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
-	const MaxDelayMs = 200
+	const MaxDelay = 200 * time.Millisecond
 
 	const MaxBatchCount = 20
 	const LogsPerBatch = 10000
@@ -76,7 +76,7 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 		}
 
 		lastCall.Store(time.Now().UnixNano())
-		time.Sleep(time.Duration(MaxDelayMs*0.7) * time.Millisecond)
+		time.Sleep(time.Duration(float64(MaxDelay) * 0.7))
 		payload, err := json.Marshal(map[string]interface{}{
 			"status":       "success",
 			"bytesCharged": 42,
@@ -92,7 +92,7 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 		Tokens:   config.DataSetTokens{WriteLog: "AAAA"},
 		BufferSettings: buffer_config.DataSetBufferSettings{
 			MaxSize:                  1000,
-			MaxLifetime:              time.Duration(MaxDelayMs) * time.Millisecond,
+			MaxLifetime:              MaxDelay,
 			RetryRandomizationFactor: 1.0,
 			RetryMultiplier:          1.0,
 			RetryInitialInterval:     RetryBase,
@@ -143,7 +143,7 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 			err := sc.AddEvents(batch)
 			assert.Nil(t, err)
 		})(batch)
-		time.Sleep(time.Duration(MaxDelayMs*0.3) * time.Millisecond)
+		time.Sleep(time.Duration(float64(MaxDelay) * 0.3))
 	}
 
 	err = sc.Shutdown()

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -203,7 +203,8 @@ func TestAddEventsRetryAfterSec(t *testing.T) {
 	eventBundle1 := &add_events.EventBundle{Event: event1, Thread: &add_events.Thread{Id: "5", Name: "fred"}}
 	err1 := sc.AddEvents([]*add_events.EventBundle{eventBundle1})
 	time.Sleep(RetryBase)
-	sc.SendAllAddEventsBuffers()
+	// we are not calling shutdown, because we want to process more events in the future
+	sc.publishAllBuffers()
 
 	// wait for processing
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
# 🥅 Goal

Make the logging during shutdown less confusing.

# 🛠️ Solution

During the shutdown process some of the events and buffers may not be processed yet. We have been logging messages like - "not all buffers has been processed". This was misleading since it was expected. Also log more clearly when the shutdown has started and when finished.

# 🏫 Testing

