### PR TITLE
CodeCov: Explicitly specify token

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -73,6 +73,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
       - name: Build Examples

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
           )
       - id: trailing-whitespace
   - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.0
+    rev: v0.5.1
     hooks:
       - id: go-fmt
       - id: go-imports
@@ -41,7 +41,7 @@ repos:
       - id: go-mod-vendor
 
   - repo: https://github.com/Bahjat/pre-commit-golang
-    rev: v1.0.2
+    rev: v1.0.3
     hooks:
       - id: go-fmt-import
       - id: go-lint


### PR DESCRIPTION
Our CI pipeline for is failing a lot in the step that is trying to upload results to CodeCov. There is the following issue - https://github.com/codecov/codecov-action/issues/557 - where people have the same problem. Their fix is to explicitly include the CODECOV_TOKEN in the step.

So I am doing the same change and we will see, whether this will help or not.