### PR TITLE
Fix failing pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,33 +22,15 @@ repos:
             test/testdata/buffer_test_payload_full.json
           )
       - id: trailing-whitespace
-  - repo: https://github.com/dnephin/pre-commit-golang
-    rev: v0.5.1
-    hooks:
-      - id: go-fmt
-      - id: go-imports
-      - id: go-cyclo
-      - id: validate-toml
-      - id: no-go-testing
-      - id: golangci-lint
-      # - id: go-critic
-      #  # args: [-disable=sloppyTypeAssert]
-      #  args: ["-v", "-enable='yodaStyleExpr'", "-disable=sloppyTypeAssert"]
-      # there is timeout of 30s for go-unit-test and we need more
-      # - id: go-unit-tests
-      - id: go-build
-      - id: go-mod-tidy
-      - id: go-mod-vendor
 
   - repo: https://github.com/Bahjat/pre-commit-golang
     rev: v1.0.3
     hooks:
       - id: go-fmt-import
       - id: go-lint
-      # - id: go-unit-tests
       - id: gofumpt
       - id: go-err-check
-      # - id: go-static-check
-      # - id: golangci-lint
+      - id: golangci-lint
+      - id: go-static-check
       # - id: go-ruleguard # requires https://github.com/quasilyte/go-ruleguard
       #    args: [rules/rules.go] # required

--- a/scripts/install-dev-tools.sh
+++ b/scripts/install-dev-tools.sh
@@ -8,4 +8,4 @@ go install -v github.com/BurntSushi/toml/cmd/tomlv@latest
 go install -v mvdan.cc/gofumpt@latest
 go install -v github.com/kisielk/errcheck@latest
 # go install -v github.com/quasilyte/go-ruleguard/cmd/ruleguard@latest
-# go install -v honnef.co/go/tools/cmd/staticcheck@latest
+go install -v honnef.co/go/tools/cmd/staticcheck@latest


### PR DESCRIPTION
Code quality check is not reliable since it's failing all the time on some strange errors.

```
go test -v -race -timeout 360s -parallel 4 -count=1 -tags=long_running,"" ./...
Error: pkg/buffer_config/buffer_config.go:23:2: cannot find package "." in:
	/home/runner/work/dataset-go/dataset-go/vendor/github.com/cenkalti/backoff/v4
Error: pkg/buffer/buffer.go:32:2: cannot find package "." in:
	/home/runner/work/dataset-go/dataset-go/vendor/github.com/google/uuid
Error: pkg/client/client.go:44:2: cannot find package "." in:
	/home/runner/work/dataset-go/dataset-go/vendor/github.com/cskr/pubsub
make: *** [Makefile:56: test-all] Error 1
Error: Process completed with exit code 2.
```

 Let's try to fix this.

I have removed `dnephin/pre-commit-golang` - pre-commit hook - https://github.com/dnephin/pre-commit-golang/issues/98 - since it was failing and it's no longer supported. And it has solved the problem.

# Testing

I have rerun pipeline 4 times and it has always succeeded. So I am going to merge it and we will see.