### PR TITLE
Fix flaky tests: Add more metrics

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -78,19 +78,12 @@ jobs:
           verbose: true
       - name: Build Examples
         run: |
-          ( cd examples/client; go build )
-          ( cd examples/readme; go build )
+          make build-examples
       - name: Check SSL Certificates
         run: |
-          cd scripts
-          ./test-ssl-certificates.sh
+          make test-ssl-certificates
       - name: Run Tests Many Times
-        # Run test multiple times to check for data races
+        # Run test multiple times to check for flaky tests
         if: github.ref_name == 'main'
         run: |
-          set -e;
-          N=10;
-          for i in `seq 1 ${N}`; do
-            echo "Running test ${i} / ${N}";
-            make test;
-          done;
+          make test-many-times COUNT=10

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -86,4 +86,4 @@ jobs:
         # Run test multiple times to check for flaky tests
         if: github.ref_name == 'main'
         run: |
-          make test-many-times COUNT=10
+          make test-many-times COUNT=5

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -175,6 +175,7 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 							buf = getBuffer(key)
 						} else {
 							client.Logger.Error("Cannot add bundle", zap.Error(err))
+							client.eventsDropped.Add(1)
 							continue
 						}
 					}
@@ -183,6 +184,8 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 					}
 					if added == buffer.TooMuch {
 						client.Logger.Fatal("Bundle was not added for second time!", buf.ZapStats()...)
+						client.eventsDropped.Add(1)
+						continue
 					}
 				}
 				client.eventsProcessed.Add(1)
@@ -194,6 +197,12 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 				if buf.PublishAsap.Load() {
 					client.publishBuffer(buf)
 				}
+			} else {
+				client.Logger.Error(
+					"Cannot convert message to EventBundle",
+					zap.Any("msg", msg),
+				)
+				client.eventsBroken.Add(1)
 			}
 		}
 	}
@@ -202,13 +211,13 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 // isProcessingBuffers returns True if there are still some unprocessed buffers.
 // False otherwise.
 func (client *DataSetClient) isProcessingBuffers() bool {
-	return client.buffersEnqueued.Load() > client.buffersProcessed.Load()
+	return client.buffersEnqueued.Load() > (client.buffersProcessed.Load() + client.buffersDropped.Load() + client.buffersBroken.Load())
 }
 
 // isProcessingEvents returns True if there are still some unprocessed events.
 // False otherwise.
 func (client *DataSetClient) isProcessingEvents() bool {
-	return client.eventsEnqueued.Load() > client.eventsProcessed.Load()
+	return client.eventsEnqueued.Load() > (client.eventsProcessed.Load() + client.eventsDropped.Load() + client.eventsBroken.Load())
 }
 
 // Shutdown takes care of shutdown of client. It does following steps
@@ -245,10 +254,11 @@ func (client *DataSetClient) Shutdown() error {
 		Stop:                backoff.Stop,
 		Clock:               backoff.SystemClock,
 	}
-	expBackoff.Reset()
 
 	// try (with timeout) to process (add into buffers) events,
 	retryNum := 0
+	expBackoff.Reset()
+	initialEventsDropped := client.eventsDropped.Load()
 	for client.isProcessingEvents() {
 		// log statistics
 		client.logStatistics()
@@ -300,7 +310,7 @@ func (client *DataSetClient) Shutdown() error {
 	// do wait (with timeout) for all buffers to be sent to the server
 	retryNum = 0
 	expBackoff.Reset()
-	initialDropped := client.buffersDropped.Load()
+	initialBuffersDropped := client.buffersDropped.Load()
 	for client.isProcessingBuffers() {
 		// log statistics
 		client.logStatistics()
@@ -350,7 +360,19 @@ func (client *DataSetClient) Shutdown() error {
 		)
 	}
 
-	buffersDropped := client.buffersDropped.Load() - initialDropped
+	eventsDropped := client.eventsDropped.Load() - initialEventsDropped
+	if eventsDropped > 0 {
+		lastError = fmt.Errorf(
+			"some events were dropped during finishing - %d",
+			eventsDropped,
+		)
+		client.Logger.Error(
+			"Shutting down - events were dropped during shutdown",
+			zap.Uint64("eventsDropped", eventsDropped),
+		)
+	}
+
+	buffersDropped := client.buffersDropped.Load() - initialBuffersDropped
 	if buffersDropped > 0 {
 		lastError = fmt.Errorf(
 			"some buffers were dropped during finishing - %d",

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -158,6 +158,6 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 	assert.Nil(t, err, err)
 
 	assert.Equal(t, seenKeys, expectedKeys)
-	assert.Equal(t, processedEvents.Load(), ExpectedLogs, "processed items")
-	assert.Equal(t, uint64(len(seenKeys)), ExpectedLogs, "unique items")
+	assert.Equal(t, int(processedEvents.Load()), int(ExpectedLogs), "processed items")
+	assert.Equal(t, int(len(seenKeys)), int(ExpectedLogs), "unique items")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -74,6 +74,7 @@ type DataSetClient struct {
 	buffersEnqueued  atomic.Uint64
 	buffersProcessed atomic.Uint64
 	buffersDropped   atomic.Uint64
+	buffersBroken    atomic.Uint64
 	// Pub/Sub topics of Buffers based on its session
 	BufferPerSessionTopic *pubsub.PubSub
 	LastHttpStatus        atomic.Uint32
@@ -87,6 +88,8 @@ type DataSetClient struct {
 	Logger           *zap.Logger
 	eventsEnqueued   atomic.Uint64
 	eventsProcessed  atomic.Uint64
+	eventsDropped    atomic.Uint64
+	eventsBroken     atomic.Uint64
 	bytesAPISent     atomic.Uint64
 	bytesAPIAccepted atomic.Uint64
 	addEventsMutex   sync.Mutex
@@ -162,6 +165,7 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 		buffersEnqueued:                 atomic.Uint64{},
 		buffersProcessed:                atomic.Uint64{},
 		buffersDropped:                  atomic.Uint64{},
+		buffersBroken:                   atomic.Uint64{},
 		buffersAllMutex:                 sync.Mutex{},
 		BufferPerSessionTopic:           pubsub.New(0),
 		LastHttpStatus:                  atomic.Uint32{},
@@ -172,6 +176,8 @@ func NewClient(cfg *config.DataSetConfig, client *http.Client, logger *zap.Logge
 		finished:                        atomic.Bool{},
 		eventsEnqueued:                  atomic.Uint64{},
 		eventsProcessed:                 atomic.Uint64{},
+		eventsDropped:                   atomic.Uint64{},
+		eventsBroken:                    atomic.Uint64{},
 		bytesAPIAccepted:                atomic.Uint64{},
 		bytesAPISent:                    atomic.Uint64{},
 		addEventsMutex:                  sync.Mutex{},
@@ -297,10 +303,14 @@ func (client *DataSetClient) listenAndSendBufferForSession(session string, ch ch
 				continue
 			}
 			client.sendBufferWithRetryPolicy(buf)
+			client.buffersProcessed.Add(1)
 		} else {
-			client.Logger.Error("Cannot convert message", zap.Any("msg", msg))
+			client.Logger.Error(
+				"Cannot convert message to Buffer",
+				zap.Any("msg", msg),
+			)
+			client.buffersBroken.Add(1)
 		}
-		client.buffersProcessed.Add(1)
 		client.lastAcceptedAt.Store(time.Now().UnixNano())
 	}
 }
@@ -422,23 +432,29 @@ func (client *DataSetClient) logStatistics() {
 	bProcessed := client.buffersProcessed.Load()
 	bEnqueued := client.buffersEnqueued.Load()
 	bDropped := client.buffersDropped.Load()
+	bBroken := client.buffersBroken.Load()
 	client.Logger.Info(
 		"Buffers' Queue Stats:",
 		zap.Uint64("processed", bProcessed),
 		zap.Uint64("enqueued", bEnqueued),
 		zap.Uint64("dropped", bDropped),
-		zap.Uint64("waiting", bEnqueued-bProcessed),
+		zap.Uint64("broken", bBroken),
+		zap.Uint64("waiting", bEnqueued-bProcessed-bDropped-bBroken),
 		zap.Float64("processingS", processingInSec),
 	)
 
 	// log events stats
 	eProcessed := client.eventsProcessed.Load()
 	eEnqueued := client.eventsEnqueued.Load()
+	eDropped := client.eventsDropped.Load()
+	eBroken := client.eventsBroken.Load()
 	client.Logger.Info(
 		"Events' Queue Stats:",
 		zap.Uint64("processed", eProcessed),
 		zap.Uint64("enqueued", eEnqueued),
-		zap.Uint64("waiting", eEnqueued-eProcessed),
+		zap.Uint64("dropped", eDropped),
+		zap.Uint64("broken", eBroken),
+		zap.Uint64("waiting", eEnqueued-eProcessed-eDropped-eBroken),
 		zap.Float64("processingS", processingInSec),
 	)
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.12.0"
+	Version      = "0.12.1"
 	ReleasedDate = "2023-07-31"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.12.0", Version)
+	assert.Equal(t, "0.12.1", Version)
 	assert.Equal(t, "2023-07-31", ReleasedDate)
 }


### PR DESCRIPTION
In the PR #46 I was hoping to fix the flaky tests. Although it is not failing on my machine and when I have run it few times as GitHub Action - it's still not clear why there is still sometimes lost event. So let's introduce more metrics to measure also lost/broken stuff to see, what is going on.

This is the flaky test - https://github.com/scalyr/dataset-go/blob/main/pkg/client/add_events_long_running_test.go - out of 200k events there is 10% chance, that one event gets lost.

There is 200_000 events enqueued in the function `AddEvents` and it's tracked by `client.eventsEnqueued`, but there is only 199_999 events processed by the function `listenAndSendBundlesForKey` and it's tracked by `client.eventsProcessed`.

There are also variables to keep track of dropped (`client.eventsDropped`) or broken events (`events.eventsBroken`) - but they are always zero. 

My only remaining theory is that I am using the underlying library - https://github.com/cskr/pubsub/ - there are some warnings in the code - https://github.com/cskr/pubsub/blob/master/pubsub.go#L176 and in the documentation - https://pkg.go.dev/github.com/cskr/pubsub

# Testing

In GitHub it has 10% chance, that it fails.
<img width="270" alt="Screenshot 2023-07-31 at 16 10 16" src="https://github.com/scalyr/dataset-go/assets/122797378/11c87f91-a118-482c-aec3-3537f6dbdd90">
On my machine it is also around 10% - `make test-many-times COUNT=10`.

