### PR TITLE
DSET-4430: Test also Go 1.20

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -82,8 +82,3 @@ jobs:
       - name: Check SSL Certificates
         run: |
           make test-ssl-certificates
-      - name: Run Tests Many Times
-        # Run test multiple times to check for flaky tests
-        if: github.ref_name == 'main'
-        run: |
-          make test-many-times COUNT=5

--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -64,9 +64,6 @@ jobs:
       - name: Run pre-commit
         run: |
           pre-commit run -a
-      - name: Code tests
-        run: |
-          make test
       - name: Code coverage
         run: |
           make coverage

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,6 +32,7 @@ jobs:
   build:
     strategy:
       matrix:
+        go: ['1.19', '1.20']
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     needs: pre_job
@@ -46,7 +47,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: ${{ matrix.go }}
           cache: true
           cache-dependency-path: |
             go.sum
@@ -60,4 +61,4 @@ jobs:
         # Run test multiple times to check for flaky tests
         # if: github.ref_name == 'main'
         run: |
-          make test-many-times COUNT=5
+          make test-many-times COUNT=2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -59,6 +59,6 @@ jobs:
           make test
       - name: Run Tests Many Times
         # Run test multiple times to check for flaky tests
-        # if: github.ref_name == 'main'
+        if: github.ref_name == 'main'
         run: |
           make test-many-times COUNT=2

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -58,6 +58,6 @@ jobs:
           make test
       - name: Run Tests Many Times
         # Run test multiple times to check for flaky tests
-        if: github.ref_name == 'main'
+        # if: github.ref_name == 'main'
         run: |
           make test-many-times COUNT=5

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,6 @@ test-many-times:
 	for i in `seq 1 $${COUNT}`; do \
 		echo "Running test $${i} / $${COUNT} - BEGIN"; \
 		make test 2>&1 | tee $${prefix}-$${i}.log | awk '{print "'$${i}'/'$${COUNT}'", $$0; }' ; \
-		echo; \
-		grep -H FAIL $${prefix}-$${i}.log; \
 		echo "Running test $${i} / $${COUNT} - END"; \
 	done; \
 	echo "Grep for FAIL - no lines should be found"; \

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-all:
 
 .PHONY: test-many-times
 test-many-times:
-	# set -e;
+	set -e; \
 	if [ "x$(COUNT)" == "x" ]; then \
 		COUNT=50; \
 	else \
@@ -67,7 +67,7 @@ test-many-times:
 	rm -rfv $${prefix}*; \
 	for i in `seq 1 $${COUNT}`; do \
 		echo "Running test $${i} / $${COUNT} - BEGIN"; \
-		make test 2>&1 | tee $${prefix}-$${i}.log | awk '{print "'$${i}'/'$${COUNT}'", $$0; }' ; \
+		make test 2>&1 | tee $${prefix}-$${i}.log | awk '{print "'$${i}'/'$${COUNT}'", $$0; }' || exit 0; \
 		echo "Running test $${i} / $${COUNT} - END"; \
 	done; \
 	echo "Grep for FAIL - no lines should be found"; \

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/scalyr/dataset-go.svg)](https://pkg.go.dev/github.com/scalyr/dataset-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/scalyr/dataset-go)](https://goreportcard.com/report/github.com/scalyr/dataset-go)
 [![Check code quality](https://github.com/scalyr/dataset-go/actions/workflows/code-quality.yaml/badge.svg)](https://github.com/scalyr/dataset-go/actions/workflows/code-quality.yaml)
+[![Check code quality](https://github.com/scalyr/dataset-go/actions/workflows/unit-tests.yaml/badge.svg)](https://github.com/scalyr/dataset-go/actions/workflows/unit-tests.yaml)
 [![TruffleHog Secrets Scan](https://github.com/scalyr/dataset-go/actions/workflows/secrets-scanner.yaml/badge.svg)](https://github.com/scalyr/dataset-go/actions/workflows/secrets-scanner.yaml)
 [![codecov](https://codecov.io/gh/scalyr/dataset-go/branch/main/graph/badge.svg?token=IFTJDLGEF5)](https://codecov.io/gh/scalyr/dataset-go)
 [![Version](https://img.shields.io/github/tag/scalyr/dataset-go.svg)](https://github.com/scalyr/dataset-go/releases)


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DSET-4430>

# 🥅 Goal

Run the same OS and Go version as Open Telemetry Contrib

# 🛠️ Solution

In the PR #50 we have started to run tests also on Windows. But we should test as well with Go 1.20, since it's used by OpenTelemetry as well - OpenTelemetryContrib is running tests for Go 1.20 as well - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/build-and-test.yml#L225

# 🏫 Testing

Test for Go 1.19 and 1.20 are executed.