### PR TITLE
DSET-4449: Do not count dropped buffer as processed

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 0.13.0
+
+* fix: do not drop event when buffer is being published
+* fix: do not double count dropped buffers
+
 ## 0.12.0
 
 * fix: make client shutdown timeout configurable.

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -171,11 +171,11 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 				} else {
 					client.Logger.Error("Cannot add bundle", zap.Error(err))
 					// TODO: what to do?
-					// in the past we have skipped it, but it was failing in CI/CD
-					// so lets wait for little bit and do not skip
-					// hopefully after this fix
+					// this error happens when the buffer is already publishing
+					// we can solve it by waiting little bit
+					// since we are also returning TooMuch we will get new buffer
+					// few lines below
 					time.Sleep(10 * time.Millisecond)
-					// continue
 				}
 			}
 

--- a/pkg/client/add_events.go
+++ b/pkg/client/add_events.go
@@ -170,8 +170,12 @@ func (client *DataSetClient) listenAndSendBundlesForKey(key string, ch chan inte
 					buf = getBuffer(key)
 				} else {
 					client.Logger.Error("Cannot add bundle", zap.Error(err))
-					// TODO: what to do? For now, lets skip it
-					continue
+					// TODO: what to do?
+					// in the past we have skipped it, but it was failing in CI/CD
+					// so lets wait for little bit and do not skip
+					// hopefully after this fix
+					time.Sleep(10 * time.Millisecond)
+					// continue
 				}
 			}
 

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -158,11 +158,19 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 	assert.Nil(t, err, err)
 
 	stats := sc.Statistics()
-	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
-	assert.Equal(t, uint64(0), stats.Buffers.Dropped)
+	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Enqueued())
+	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Processed())
+	assert.Equal(t, uint64(0), stats.Events.Waiting())
+	assert.Equal(t, uint64(0), stats.Events.Dropped())
+	assert.Equal(t, uint64(0), stats.Events.Broken())
+	assert.Equal(t, 1.0, stats.Events.SuccessRate())
 
-	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Enqueued)
-	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Processed)
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting())
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped())
+	assert.Equal(t, uint64(0), stats.Buffers.Broken())
+	assert.Equal(t, 1.0, stats.Buffers.SuccessRate())
+
+	assert.Equal(t, 1.0, stats.Transfer.SuccessRate())
 
 	assert.Equal(t, seenKeys, expectedKeys)
 	assert.Equal(t, int(processedEvents.Load()), int(ExpectedLogs), "processed items")

--- a/pkg/client/add_events_long_running_test.go
+++ b/pkg/client/add_events_long_running_test.go
@@ -157,6 +157,13 @@ func TestAddEventsManyLogsShouldSucceed(t *testing.T) {
 	err = sc.Shutdown()
 	assert.Nil(t, err, err)
 
+	stats := sc.Statistics()
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped)
+
+	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Enqueued)
+	assert.Equal(t, uint64(ExpectedLogs), stats.Events.Processed)
+
 	assert.Equal(t, seenKeys, expectedKeys)
 	assert.Equal(t, int(processedEvents.Load()), int(ExpectedLogs), "processed items")
 	assert.Equal(t, int(len(seenKeys)), int(ExpectedLogs), "unique items")

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -238,8 +238,11 @@ func TestAddEventsRetryAfterSec(t *testing.T) {
 	wasSuccessful.Store(false)
 	assert.Nil(t, err2)
 	assert.Nil(t, sc.LastError())
-	// info2 := httpmock.GetCallCountInfo()
-	// assert.CmpDeeply(info2, map[string]int{"POST https://example.com/api/addEvents": 3})
+
+	stats := sc.Statistics()
+	assert.Equal(t, uint64(2), stats.Buffers.Enqueued)
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped)
 }
 
 func TestAddEventsRetryAfterTime(t *testing.T) {
@@ -578,6 +581,12 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	err = sc.AddEvents([]*add_events.EventBundle{eventBundle1})
 	assert.Nil(t, err)
 	err = sc.Shutdown()
+
+	stats := sc.Statistics()
+	assert.Equal(t, uint64(1), stats.Buffers.Enqueued)
+	assert.Equal(t, uint64(0), stats.Buffers.Processed)
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
+	assert.Equal(t, uint64(1), stats.Buffers.Dropped)
 
 	assert.NotNil(t, err)
 	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -153,9 +153,11 @@ func TestAddEventsRetry(t *testing.T) {
 	assert.Equal(t, 1.0, stats.Buffers.SuccessRate())
 	assert.Equal(t, 1.0/float64(succeedInAttempt), stats.Transfer.SuccessRate())
 	assert.Equal(t, uint64(1), stats.Transfer.BuffersProcessed())
+	/* TODO: on my Mac it's 337 in GitHub action on ubuntu-latest it's 339
 	assert.Equal(t, uint64(0x3f3), stats.Transfer.BytesSent())
 	assert.Equal(t, uint64(0x151), stats.Transfer.BytesAccepted())
 	assert.Equal(t, 337.0, stats.Transfer.AvgBufferBytes())
+	*/
 }
 
 func TestAddEventsRetryAfterSec(t *testing.T) {

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -135,11 +135,27 @@ func TestAddEventsRetry(t *testing.T) {
 	assert.Nil(t, err)
 	err = sc.Shutdown()
 	assert.Nil(t, err)
-
 	assert.True(t, wasSuccessful.Load())
-	assert.Nil(t, err)
-
 	assert.Equal(t, attempt.Load(), succeedInAttempt)
+
+	stats := sc.Statistics()
+	assert.Equal(t, uint64(1), stats.Events.Enqueued())
+	assert.Equal(t, uint64(1), stats.Events.Processed())
+	assert.Equal(t, uint64(0), stats.Events.Waiting())
+	assert.Equal(t, uint64(0), stats.Events.Dropped())
+	assert.Equal(t, uint64(0), stats.Events.Broken())
+	assert.Equal(t, 1.0, stats.Events.SuccessRate())
+	assert.Equal(t, uint64(1), stats.Buffers.Enqueued())
+	assert.Equal(t, uint64(1), stats.Buffers.Processed())
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting())
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped())
+	assert.Equal(t, uint64(0), stats.Buffers.Broken())
+	assert.Equal(t, 1.0, stats.Buffers.SuccessRate())
+	assert.Equal(t, 1.0/float64(succeedInAttempt), stats.Transfer.SuccessRate())
+	assert.Equal(t, uint64(1), stats.Transfer.BuffersProcessed())
+	assert.Equal(t, uint64(0x3f3), stats.Transfer.BytesSent())
+	assert.Equal(t, uint64(0x151), stats.Transfer.BytesAccepted())
+	assert.Equal(t, 337.0, stats.Transfer.AvgBufferBytes())
 }
 
 func TestAddEventsRetryAfterSec(t *testing.T) {
@@ -240,9 +256,9 @@ func TestAddEventsRetryAfterSec(t *testing.T) {
 	assert.Nil(t, sc.LastError())
 
 	stats := sc.Statistics()
-	assert.Equal(t, uint64(2), stats.Buffers.Enqueued)
-	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
-	assert.Equal(t, uint64(0), stats.Buffers.Dropped)
+	assert.Equal(t, uint64(2), stats.Buffers.Enqueued())
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting())
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped())
 }
 
 func TestAddEventsRetryAfterTime(t *testing.T) {
@@ -391,12 +407,27 @@ func TestAddEventsLargeEvent(t *testing.T) {
 	assert.Nil(t, err)
 	err = sc.Shutdown()
 	assert.Nil(t, err)
-
 	assert.True(t, wasSuccessful.Load())
-	assert.Nil(t, err)
 	assert.Nil(t, sc.LastError())
-	// info := httpmock.GetCallCountInfo()
-	// assert.CmpDeeply(info, map[string]int{"POST https://example.com/api/addEvents": 1})
+
+	stats := sc.Statistics()
+	assert.Equal(t, uint64(1), stats.Events.Enqueued())
+	assert.Equal(t, uint64(1), stats.Events.Processed())
+	assert.Equal(t, uint64(0), stats.Events.Waiting())
+	assert.Equal(t, uint64(0), stats.Events.Dropped())
+	assert.Equal(t, uint64(0), stats.Events.Broken())
+	assert.Equal(t, 1.0, stats.Events.SuccessRate())
+	assert.Equal(t, uint64(2), stats.Buffers.Enqueued())
+	assert.Equal(t, uint64(2), stats.Buffers.Processed())
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting())
+	assert.Equal(t, uint64(0), stats.Buffers.Dropped())
+	assert.Equal(t, uint64(0), stats.Buffers.Broken())
+	assert.Equal(t, 1.0, stats.Buffers.SuccessRate())
+	assert.Equal(t, 1.0, stats.Transfer.SuccessRate())
+	assert.Equal(t, uint64(2), stats.Transfer.BuffersProcessed())
+	assert.Equal(t, uint64(0x5f006d), stats.Transfer.BytesSent())
+	assert.Equal(t, uint64(0x5f006d), stats.Transfer.BytesAccepted())
+	assert.Equal(t, 3113014.5, stats.Transfer.AvgBufferBytes())
 }
 
 func TestAddEventsLargeEventThatNeedEscaping(t *testing.T) {
@@ -583,10 +614,19 @@ func TestAddEventsDoNotRetryForever(t *testing.T) {
 	err = sc.Shutdown()
 
 	stats := sc.Statistics()
-	assert.Equal(t, uint64(1), stats.Buffers.Enqueued)
-	assert.Equal(t, uint64(0), stats.Buffers.Processed)
-	assert.Equal(t, uint64(0), stats.Buffers.Waiting)
-	assert.Equal(t, uint64(1), stats.Buffers.Dropped)
+	assert.Equal(t, uint64(1), stats.Events.Enqueued())
+	assert.Equal(t, uint64(1), stats.Events.Processed())
+	assert.Equal(t, uint64(0), stats.Events.Waiting())
+	assert.Equal(t, uint64(0), stats.Events.Dropped())
+	assert.Equal(t, uint64(0), stats.Events.Broken())
+	assert.Equal(t, 1.0, stats.Events.SuccessRate())
+	assert.Equal(t, uint64(1), stats.Buffers.Enqueued())
+	assert.Equal(t, uint64(0), stats.Buffers.Processed())
+	assert.Equal(t, uint64(0), stats.Buffers.Waiting())
+	assert.Equal(t, uint64(1), stats.Buffers.Dropped())
+	assert.Equal(t, uint64(0), stats.Buffers.Broken())
+	assert.Equal(t, 0.0, stats.Buffers.SuccessRate())
+	assert.Equal(t, 0.0, stats.Transfer.SuccessRate())
 
 	assert.NotNil(t, err)
 	assert.Errorf(t, err, "some buffers were dropped during finishing - 1")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -421,6 +421,7 @@ func (client *DataSetClient) statisticsSweeper() {
 	}
 }
 
+// Statistics returns statistics about events, buffers processing from the start time
 func (client *DataSetClient) Statistics() *Statistics {
 	// for how long are events being processed
 	firstAt := time.Unix(0, client.firstReceivedAt.Load())

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -307,8 +307,9 @@ func (client *DataSetClient) listenAndSendBufferForSession(session string, ch ch
 				client.buffersProcessed.Add(1)
 				continue
 			}
-			client.sendBufferWithRetryPolicy(buf)
-			client.buffersProcessed.Add(1)
+			if client.sendBufferWithRetryPolicy(buf) {
+				client.buffersProcessed.Add(1)
+			}
 		} else {
 			client.Logger.Error(
 				"Cannot convert message to Buffer",
@@ -322,7 +323,7 @@ func (client *DataSetClient) listenAndSendBufferForSession(session string, ch ch
 }
 
 // Sends buffer to DataSet. If not succeeds and try is possible (it retryable), try retry until possible (timeout)
-func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) {
+func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) bool {
 	// Do not use NewExponentialBackOff since it calls Reset and the code here must
 	// call Reset after changing the InitialInterval (this saves an unnecessary call to Now).
 	expBackoff := backoff.ExponentialBackOff{
@@ -347,7 +348,7 @@ func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) {
 				lastHttpStatus = HttpErrorHasErrorMessage
 				client.LastHttpStatus.Store(lastHttpStatus)
 				client.onBufferDrop(buf, lastHttpStatus, err)
-				break // exit loop (failed to send buffer)
+				return false // exit loop (failed to send buffer)
 			}
 			lastHttpStatus = HttpErrorCannotConnect
 			client.LastHttpStatus.Store(lastHttpStatus)
@@ -375,7 +376,7 @@ func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) {
 		if isOkStatus(lastHttpStatus) {
 			// everything was fine, there is no need for retries
 			client.bytesAPIAccepted.Add(uint64(payloadLen))
-			break // exit loop (buffer sent)
+			return true // exit loop (buffer sent)
 		}
 
 		backoffDelay := expBackoff.NextBackOff()
@@ -384,7 +385,7 @@ func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) {
 			// throw away the batch
 			err = fmt.Errorf("max elapsed time expired %w", err)
 			client.onBufferDrop(buf, lastHttpStatus, err)
-			break // exit loop (failed to send buffer)
+			return false // exit loop (failed to send buffer)
 		}
 
 		if isRetryableStatus(lastHttpStatus) {
@@ -406,7 +407,7 @@ func (client *DataSetClient) sendBufferWithRetryPolicy(buf *buffer.Buffer) {
 		} else {
 			err = fmt.Errorf("non recoverable error %w", err)
 			client.onBufferDrop(buf, lastHttpStatus, err)
-			break // exit loop (failed to send buffer)
+			return false // exit loop (failed to send buffer)
 		}
 		retryNum++
 	}
@@ -420,7 +421,7 @@ func (client *DataSetClient) statisticsSweeper() {
 	}
 }
 
-func (client *DataSetClient) logStatistics() {
+func (client *DataSetClient) Statistics() *Statistics {
 	mb := float64(1024 * 1024)
 
 	// for how long are events being processed
@@ -431,7 +432,7 @@ func (client *DataSetClient) logStatistics() {
 
 	// if nothing was processed, do not log statistics
 	if processingInSec <= 0 {
-		return
+		return nil
 	}
 
 	// log buffer stats
@@ -439,30 +440,30 @@ func (client *DataSetClient) logStatistics() {
 	bEnqueued := client.buffersEnqueued.Load()
 	bDropped := client.buffersDropped.Load()
 	bBroken := client.buffersBroken.Load()
-	client.Logger.Info(
-		"Buffers' Queue Stats:",
-		zap.Uint64("processed", bProcessed),
-		zap.Uint64("enqueued", bEnqueued),
-		zap.Uint64("dropped", bDropped),
-		zap.Uint64("broken", bBroken),
-		zap.Uint64("waiting", bEnqueued-bProcessed-bDropped-bBroken),
-		zap.Float64("processingS", processingInSec),
-	)
+
+	buffersStats := QueueStats{
+		bProcessed,
+		bEnqueued,
+		bDropped,
+		bBroken,
+		bEnqueued - bProcessed - bDropped - bBroken,
+		processingInSec,
+	}
 
 	// log events stats
 	eProcessed := client.eventsProcessed.Load()
 	eEnqueued := client.eventsEnqueued.Load()
 	eDropped := client.eventsDropped.Load()
 	eBroken := client.eventsBroken.Load()
-	client.Logger.Info(
-		"Events' Queue Stats:",
-		zap.Uint64("processed", eProcessed),
-		zap.Uint64("enqueued", eEnqueued),
-		zap.Uint64("dropped", eDropped),
-		zap.Uint64("broken", eBroken),
-		zap.Uint64("waiting", eEnqueued-eProcessed-eDropped-eBroken),
-		zap.Float64("processingS", processingInSec),
-	)
+
+	eventsStats := QueueStats{
+		eProcessed,
+		eEnqueued,
+		eDropped,
+		eBroken,
+		eEnqueued - eProcessed - eDropped - eBroken,
+		processingInSec,
+	}
 
 	// log transferred stats
 	bAPISent := float64(client.bytesAPISent.Load())
@@ -470,15 +471,63 @@ func (client *DataSetClient) logStatistics() {
 	throughput := bAPIAccepted / mb / processingInSec
 	successRate := (bAPIAccepted + 1) / (bAPISent + 1)
 	perBuffer := (bAPIAccepted) / float64(bProcessed)
+	transferStats := TransferStats{
+		bAPISent / mb,
+		bAPIAccepted / mb,
+		throughput,
+		perBuffer / mb,
+		successRate,
+		processingInSec,
+		processingDur,
+	}
+
+	return &Statistics{
+		Buffers:  buffersStats,
+		Events:   eventsStats,
+		Transfer: transferStats,
+	}
+}
+
+func (client *DataSetClient) logStatistics() {
+	stats := client.Statistics()
+	if stats == nil {
+		return
+	}
+
+	b := stats.Buffers
+	client.Logger.Info(
+		"Buffers' Queue Stats:",
+		zap.Uint64("processed", b.Processed),
+		zap.Uint64("enqueued", b.Enqueued),
+		zap.Uint64("dropped", b.Dropped),
+		zap.Uint64("broken", b.Broken),
+		zap.Uint64("waiting", b.Waiting),
+		zap.Float64("processingS", b.ProcessingS),
+	)
+
+	// log events stats
+	e := stats.Events
+	client.Logger.Info(
+		"Events' Queue Stats:",
+		zap.Uint64("processed", e.Processed),
+		zap.Uint64("enqueued", e.Enqueued),
+		zap.Uint64("dropped", e.Dropped),
+		zap.Uint64("broken", e.Broken),
+		zap.Uint64("waiting", e.Waiting),
+		zap.Float64("processingS", e.ProcessingS),
+	)
+
+	// log transferred stats
+	t := stats.Transfer
 	client.Logger.Info(
 		"Transfer Stats:",
-		zap.Float64("bytesSentMB", bAPISent/mb),
-		zap.Float64("bytesAcceptedMB", bAPIAccepted/mb),
-		zap.Float64("throughputMBpS", throughput),
-		zap.Float64("perBufferMB", perBuffer/mb),
-		zap.Float64("successRate", successRate),
-		zap.Float64("processingS", processingInSec),
-		zap.Duration("processing", processingDur),
+		zap.Float64("bytesSentMB", t.BytesSentMB),
+		zap.Float64("bytesAcceptedMB", t.BytesAcceptedMB),
+		zap.Float64("throughputMBpS", t.ThroughputMBpS),
+		zap.Float64("perBufferMB", t.PerBufferMB),
+		zap.Float64("successRate", t.SuccessRate),
+		zap.Float64("processingS", t.ProcessingS),
+		zap.Duration("processing", t.Processing),
 	)
 }
 

--- a/pkg/client/statistics.go
+++ b/pkg/client/statistics.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"time"
+)
+
+type QueueStats struct {
+	Processed   uint64  `mapstructure:"processed"`
+	Enqueued    uint64  `mapstructure:"enqueued"`
+	Dropped     uint64  `mapstructure:"dropped"`
+	Broken      uint64  `mapstructure:"broken"`
+	Waiting     uint64  `mapstructure:"waiting"`
+	ProcessingS float64 `mapstructure:"processingS"`
+}
+
+type TransferStats struct {
+	BytesSentMB     float64       `mapstructure:"bytesSentMB"`
+	BytesAcceptedMB float64       `mapstructure:"bytesAcceptedMB"`
+	ThroughputMBpS  float64       `mapstructure:"throughputMBpS"`
+	PerBufferMB     float64       `mapstructure:"perBufferMB"`
+	SuccessRate     float64       `mapstructure:"successRate"`
+	ProcessingS     float64       `mapstructure:"processingS"`
+	Processing      time.Duration `mapstructure:"processing"`
+}
+
+type Statistics struct {
+	Buffers  QueueStats    `mapstructure:"buffers"`
+	Events   QueueStats    `mapstructure:"events"`
+	Transfer TransferStats `mapstructure:"transfer"`
+}

--- a/pkg/client/statistics.go
+++ b/pkg/client/statistics.go
@@ -4,26 +4,123 @@ import (
 	"time"
 )
 
+// QueueStats stores statistics related to the queue processing
 type QueueStats struct {
-	Processed   uint64  `mapstructure:"processed"`
-	Enqueued    uint64  `mapstructure:"enqueued"`
-	Dropped     uint64  `mapstructure:"dropped"`
-	Broken      uint64  `mapstructure:"broken"`
-	Waiting     uint64  `mapstructure:"waiting"`
-	ProcessingS float64 `mapstructure:"processingS"`
+	// enqueued is number of items that has been accepted for processing
+	enqueued uint64 `mapstructure:"enqueued"`
+	// Processed is number of items that has been successfully processed
+	processed uint64 `mapstructure:"processed"`
+	// dropped is number of items that has been dropped since they couldn't be processed
+	dropped uint64 `mapstructure:"dropped"`
+	// broken is number of items that has been damaged by queue, should be zero
+	broken uint64 `mapstructure:"broken"`
+	// processingTime is duration of the processing
+	processingTime time.Duration `mapstructure:"processingTime"`
 }
 
+// Enqueued is number of items that has been accepted for processing
+func (stats QueueStats) Enqueued() uint64 {
+	return stats.enqueued
+}
+
+// Processed is number of items that has been successfully processed
+func (stats QueueStats) Processed() uint64 {
+	return stats.processed
+}
+
+// Dropped is number of items that has been dropped since they couldn't be processed
+func (stats QueueStats) Dropped() uint64 {
+	return stats.dropped
+}
+
+// Broken is number of items that has been damaged by queue, should be zero
+func (stats QueueStats) Broken() uint64 {
+	return stats.broken
+}
+
+// Waiting is number of items that are waiting for being processed
+// Enqueued - Processed - Dropped - Broken
+func (stats QueueStats) Waiting() uint64 {
+	return stats.enqueued - stats.processed - stats.dropped - stats.broken
+}
+
+// SuccessRate of items processing
+// (Processed - Dropped - Broken) / Processed
+func (stats QueueStats) SuccessRate() float64 {
+	if stats.processed > 0 {
+		return float64(stats.processed-stats.dropped-stats.broken) / float64(stats.processed)
+	} else {
+		return 0.0
+	}
+}
+
+// ProcessingTime is duration of the processing
+func (stats QueueStats) ProcessingTime() time.Duration {
+	return stats.processingTime
+}
+
+// TransferStats stores statistics related to the data transfers
 type TransferStats struct {
-	BytesSentMB     float64       `mapstructure:"bytesSentMB"`
-	BytesAcceptedMB float64       `mapstructure:"bytesAcceptedMB"`
-	ThroughputMBpS  float64       `mapstructure:"throughputMBpS"`
-	PerBufferMB     float64       `mapstructure:"perBufferMB"`
-	SuccessRate     float64       `mapstructure:"successRate"`
-	ProcessingS     float64       `mapstructure:"processingS"`
-	Processing      time.Duration `mapstructure:"processing"`
+	// bytesSent is the amount of bytes that were sent to the server
+	// each retry is counted
+	bytesSent uint64 `mapstructure:"bytesSentMB"`
+	// bytesAccepted is the amount of MB that were accepted by the server
+	// retries are not counted
+	bytesAccepted uint64 `mapstructure:"bytesAcceptedMB"`
+	// buffersProcessed is number of processed buffers
+	buffersProcessed uint64
+	// processingTime is duration of the processing
+	processingTime time.Duration `mapstructure:"processingTime"`
 }
 
+// BytesSent is the amount of bytes that were sent to the server
+// each retry is counted
+func (stats TransferStats) BytesSent() uint64 {
+	return stats.bytesSent
+}
+
+// BytesAccepted is the amount of MB that were accepted by the server
+// retries are not counted
+func (stats TransferStats) BytesAccepted() uint64 {
+	return stats.bytesAccepted
+}
+
+// BuffersProcessed is number of processed buffers
+func (stats TransferStats) BuffersProcessed() uint64 {
+	return stats.buffersProcessed
+}
+
+// ThroughputBpS is the throughput based on BytesAccepted
+func (stats TransferStats) ThroughputBpS() float64 {
+	return float64(stats.bytesAccepted) / stats.processingTime.Seconds()
+}
+
+// SuccessRate of the transfer - BytesAccepted / BytesSent
+func (stats TransferStats) SuccessRate() float64 {
+	if stats.bytesSent > 0 {
+		return float64(stats.bytesAccepted) / float64(stats.bytesSent)
+	} else {
+		return 0.0
+	}
+}
+
+// AvgBufferBytes is average buffer size in bytes - BytesAccepted / BuffersProcessed
+func (stats TransferStats) AvgBufferBytes() float64 {
+	if stats.buffersProcessed > 0 {
+		return float64(stats.bytesAccepted) / float64(stats.buffersProcessed)
+	} else {
+		return 0
+	}
+}
+
+// ProcessingTime is duration of the processing
+func (stats TransferStats) ProcessingTime() time.Duration {
+	return stats.processingTime
+}
+
+// Statistics store statistics about queues and transferred data
 type Statistics struct {
+	// Buffers stores
 	Buffers  QueueStats    `mapstructure:"buffers"`
 	Events   QueueStats    `mapstructure:"events"`
 	Transfer TransferStats `mapstructure:"transfer"`

--- a/pkg/client/statistics.go
+++ b/pkg/client/statistics.go
@@ -119,9 +119,12 @@ func (stats TransferStats) ProcessingTime() time.Duration {
 }
 
 // Statistics store statistics about queues and transferred data
+// These are statistics from the beginning of the processing
 type Statistics struct {
-	// Buffers stores
-	Buffers  QueueStats    `mapstructure:"buffers"`
-	Events   QueueStats    `mapstructure:"events"`
+	// Events stores statistics about processing events
+	Events QueueStats `mapstructure:"events"`
+	// Buffers stores statistics about processing buffers
+	Buffers QueueStats `mapstructure:"buffers"`
+	// Transfer stores statistics about data transfers
 	Transfer TransferStats `mapstructure:"transfer"`
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.12.1"
-	ReleasedDate = "2023-07-31"
+	Version      = "0.13.0"
+	ReleasedDate = "2023-08-23"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.12.1", Version)
-	assert.Equal(t, "2023-07-31", ReleasedDate)
+	assert.Equal(t, "0.13.0", Version)
+	assert.Equal(t, "2023-08-23", ReleasedDate)
 }


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DSET-4449>

# 🥅 Goal

In the PR #47 I have added counting for dropped and broken buffers. However I haven't adjusted the counting for processed buffers. So when the buffer was dropped we have counted it twice - `enqueued < processed + dropped`.

# 🛠️ Solution

I have refactored the function `DatasetClient.logStatistics()` into two functions - `DatasetClient.Statistics()`, which count the statistics,  and `DatasetClient.logStatistics()`, which logs statistics.

So after fixing that bug it allowed me to write tests to verify that the statistics are computed correctly.

# 🏫 Testing

Add unit tests.