### PR TITLE
DSET-4456: Drop testing for Go 1.19 and add 1.21

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
           cache: true
           cache-dependency-path: |
             go.sum

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go: ['1.19', '1.20']
+        go: ['1.20', '1.21']
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     needs: pre_job

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 0.14.0
+
+* break: drop support for Go 1.19 and add testing for Go 1.21
+
 ## 0.13.0
 
 * fix: do not drop event when buffer is being published

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/scalyr/dataset-go
 
-go 1.19
+go 1.20
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.13.0"
+	Version      = "0.14.0"
 	ReleasedDate = "2023-08-23"
 )

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -23,6 +23,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.13.0", Version)
+	assert.Equal(t, "0.14.0", Version)
 	assert.Equal(t, "2023-08-23", ReleasedDate)
 }


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DSET-4456>

# 🥅 Goal

Go 1.19 is no longer supported - https://endoflife.date/go, and also open telemetry is no longer testing for 1.19 - https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/25116 - we should do the same.

# 🛠️ Solution

Do the same as open telemetry - drop 1.19 and add 1.21.

# 🏫 Testing

Unit testing
