### PR TITLE
DSET-4456: Use Go 1.20 and not 1.2 in CI/CD pipeline

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: '1.20'
           cache: true
           cache-dependency-path: |
             go.sum


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DSET-4456>

# 🥅 Goal

In the PR #53 I have switched Go version from 1.19 to to 1.20. But there is some GHA feature, that it treats as 1.2. This can be seen in the Dependabot PR - https://github.com/scalyr/dataset-go/actions/runs/5960922153/job/16169141080?pr=49#step:4:31 - which has failed because some tools cannot be installed with Go 1.2.

But when I check the same action in the PR #53 - it has failed - https://github.com/scalyr/dataset-go/actions/runs/5952594475/job/16144912841. I have enabled auto merge, but I haven't expected, that it will be merged, when there is some failing action.

<img width="851" alt="Screenshot 2023-08-24 at 9 59 23" src="https://github.com/scalyr/dataset-go/assets/122797378/4e946758-ad26-4fa0-a5de-fcf88ee06a7e">

# 🛠️ Solution

Fix the notation so that Go 1.20 is used instead of 1.2

# 🏫 Testing

Check that the pipeline succeeds.
