### PR TITLE
DSET-4455: Fix flaky test on MacOS

### DIFF
--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -84,7 +84,13 @@ func (s byKey) Swap(i, j int) {
 }
 
 func (s byKey) Less(i, j int) bool {
-	return s[i][0][attributeKey].(string) < s[j][0][attributeKey].(string)
+	if s[i][0][attributeKey] == nil {
+		return true
+	} else if s[j][0][attributeKey] == nil {
+		return false
+	} else {
+		return s[i][0][attributeKey].(string) < s[j][0][attributeKey].(string)
+	}
 }
 
 func TestAddEventsRetry(t *testing.T) {


### PR DESCRIPTION
Jira Link: <https://sentinelone.atlassian.net/browse/DSET-4455>

# 🥅 Goal

Make the testing code more robust - https://github.com/scalyr/dataset-go/actions/runs/5940931848/job/16110629894?pr=52 - this has failed just once and I do not know, how this could happen.

# 🛠️ Solution

Just check for the null in the testing code before converting to string.

# 🏫 Testing

unit tests are still passing