### PR TITLE
Metrics: add attributes and switch to snake_case

### DIFF
--- a/examples/client/main.go
+++ b/examples/client/main.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/scalyr/dataset-go/pkg/meter_config"
+
 	"go.opentelemetry.io/otel"
 
 	"github.com/scalyr/dataset-go/pkg/server_host_config"
@@ -67,7 +69,7 @@ func main() {
 		&http.Client{},
 		zap.Must(zap.NewDevelopment()),
 		&libraryConsumerUserAgentSuffix,
-		&meter,
+		meter_config.NewMeterConfig(&meter, "all", "example"),
 	)
 	if err != nil {
 		panic(err)

--- a/examples/readme/main.go
+++ b/examples/readme/main.go
@@ -21,6 +21,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/scalyr/dataset-go/pkg/meter_config"
+
 	"go.opentelemetry.io/otel"
 
 	"github.com/scalyr/dataset-go/pkg/server_host_config"
@@ -84,7 +86,7 @@ func main() {
 	libraryConsumerUserAgentSuffix := "OtelCollector-readme;1.2.3"
 	meter := otel.Meter("example.readme")
 	// build client
-	cl, err := client.NewClient(cfg, &http.Client{}, logger, &libraryConsumerUserAgentSuffix, &meter)
+	cl, err := client.NewClient(cfg, &http.Client{}, logger, &libraryConsumerUserAgentSuffix, meter_config.NewMeterConfig(&meter, "all", "example"))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/add_events_test.go
+++ b/pkg/client/add_events_test.go
@@ -31,10 +31,10 @@ import (
 	"testing"
 	"time"
 
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
+	"github.com/scalyr/dataset-go/pkg/meter_config"
 
 	"github.com/scalyr/dataset-go/pkg/server_host_config"
+	"go.opentelemetry.io/otel"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -241,7 +241,7 @@ func TestAddEvents(t *testing.T) {
 	meter := otel.Meter("test")
 	tests := []struct {
 		name  string
-		meter *metric.Meter
+		meter *meter_config.MeterConfig
 	}{
 		{
 			name:  "no meter",
@@ -249,7 +249,7 @@ func TestAddEvents(t *testing.T) {
 		},
 		{
 			name:  "with meter",
-			meter: &meter,
+			meter: meter_config.NewMeterConfig(&meter, "e", "n"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/scalyr/dataset-go/pkg/meter_config"
+
 	"golang.org/x/exp/slices"
 
 	"github.com/scalyr/dataset-go/pkg/version"
@@ -43,7 +45,6 @@ import (
 
 	"github.com/cskr/pubsub"
 	"github.com/google/uuid"
-	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 )
 
@@ -104,7 +105,7 @@ func NewClient(
 	client *http.Client,
 	logger *zap.Logger,
 	userAgentSuffix *string,
-	meter *metric.Meter,
+	meterConfig *meter_config.MeterConfig,
 ) (*DataSetClient, error) {
 	logger.Info(
 		"Using config: ",
@@ -158,7 +159,7 @@ func NewClient(
 	}
 	logger.Info("Using User-Agent: ", zap.String("User-Agent", userAgent))
 
-	stats, err := statistics.NewStatistics(meter, logger)
+	stats, err := statistics.NewStatistics(meterConfig, logger)
 	if err != nil {
 		return nil, fmt.Errorf("it was not possible to create statistics: %w", err)
 	}

--- a/pkg/meter_config/meter_config.go
+++ b/pkg/meter_config/meter_config.go
@@ -14,15 +14,32 @@
  * limitations under the License.
  */
 
-package version
+package meter_config
 
-import (
-	"testing"
+import "go.opentelemetry.io/otel/metric"
 
-	"github.com/stretchr/testify/assert"
-)
+type MeterConfig struct {
+	entity string
+	name   string
+	meter  *metric.Meter
+}
 
-func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.17.0", Version)
-	assert.Equal(t, "2023-11-27", ReleasedDate)
+func NewMeterConfig(meter *metric.Meter, entity string, name string) *MeterConfig {
+	return &MeterConfig{
+		entity: entity,
+		name:   name,
+		meter:  meter,
+	}
+}
+
+func (c *MeterConfig) Entity() string {
+	return c.entity
+}
+
+func (c *MeterConfig) Name() string {
+	return c.name
+}
+
+func (c *MeterConfig) Meter() *metric.Meter {
+	return c.meter
 }

--- a/pkg/meter_config/meter_config_test.go
+++ b/pkg/meter_config/meter_config_test.go
@@ -14,15 +14,19 @@
  * limitations under the License.
  */
 
-package version
+package meter_config
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel"
 )
 
-func TestVersion(t *testing.T) {
-	assert.Equal(t, "0.17.0", Version)
-	assert.Equal(t, "2023-11-27", ReleasedDate)
+func TestNewMeterConfig(t *testing.T) {
+	meter := otel.Meter("AAA")
+	cfg := NewMeterConfig(&meter, "entity", "name")
+	assert.Equal(t, "entity", cfg.Entity())
+	assert.Equal(t, "name", cfg.Name())
+	assert.NotNil(t, cfg.Meter())
 }

--- a/pkg/statistics/statistics_test.go
+++ b/pkg/statistics/statistics_test.go
@@ -21,28 +21,32 @@ import (
 	"testing"
 	"time"
 
+	"github.com/scalyr/dataset-go/pkg/meter_config"
+
 	"go.uber.org/zap"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/metric"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var (
 	meter = otel.Meter("test")
 	tests = []struct {
 		name  string
-		meter *metric.Meter
+		meter *meter_config.MeterConfig
 	}{
 		{
-			name:  "no meter",
+			name:  "no config",
 			meter: nil,
 		},
 		{
+			name:  "no meter",
+			meter: meter_config.NewMeterConfig(nil, "e", "n"),
+		},
+		{
 			name:  "with meter",
-			meter: &meter,
+			meter: meter_config.NewMeterConfig(&meter, "e", "n"),
 		},
 	}
 )

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,6 +17,6 @@
 package version
 
 const (
-	Version      = "0.16.0"
-	ReleasedDate = "2023-11-21"
+	Version      = "0.17.0"
+	ReleasedDate = "2023-11-27"
 )


### PR DESCRIPTION
Jira Link: https://sentinelone.atlassian.net/browse/DSET-4558

# 🥅 Goal

I have received feedback in the PR in the Otel Contrib - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29446#issuecomment-1827431693 that:
* metric names should be `snake_case`
* there should be support for attributes

# 🛠️ Solution

I have renamed the metrics as well as introduced possibility to pass the processing entities as well as name.

# 🏫 Testing

Same as in the PR #61 

But add more dataset exporters in the demo repository - `src/otelcollector/otelcol-config.yml`
```
service:
  pipelines:
    traces:
      receivers: [otlp]
      processors: [batch, attributes]
      exporters: [otlp, debug, spanmetrics, dataset, dataset/aaa, dataset/bbb, dataset/ccc, dataset/ddd]
    metrics:
      receivers: [httpcheck/frontendproxy, otlp, spanmetrics, prometheus]
      processors: [filter/ottl, transform, batch]
      exporters: [otlphttp/prometheus, debug]
    logs:
      receivers: [otlp]
      processors: [batch, attributes]
      exporters: [otlp/logs, debug, dataset, dataset/aaa, dataset/bbb, dataset/ccc, dataset/ddd]
```

We can see, that metrics are now `snake_case`:
<img width="838" alt="Screenshot 2023-11-27 at 12 29 29" src="https://github.com/scalyr/dataset-go/assets/122797378/eb0211a7-0f44-445b-9b2d-807167882f6d">

And it's possible to separate metrics based on `entity` (logs/traces) and `name`:
<img width="1356" alt="Screenshot 2023-11-27 at 12 59 10" src="https://github.com/scalyr/dataset-go/assets/122797378/b551c317-6a8f-41ae-9bff-f65e4ba231f7">