### PR TITLE
Replace Go 1.21 with Go 1.23

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.23'
           cache: true
           cache-dependency-path: |
             go.sum

--- a/.github/workflows/stress-tests.yaml
+++ b/.github/workflows/stress-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       # keep in sync with https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/build-and-test.yml#L237
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.22', '1.23']
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       # keep in sync with https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/.github/workflows/build-and-test.yml#L237
       matrix:
-        go: ['1.21', '1.22']
+        go: ['1.23', '1.22']
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     needs: pre_job

--- a/examples/client/go.mod
+++ b/examples/client/go.mod
@@ -1,7 +1,8 @@
 module client
 
-go 1.21
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.5
 
 require (
 	github.com/scalyr/dataset-go v0.0.0

--- a/examples/readme/go.mod
+++ b/examples/readme/go.mod
@@ -1,7 +1,8 @@
 module readme
 
-go 1.21
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.23.5
 
 require (
 	github.com/scalyr/dataset-go v0.0.0

--- a/examples/stress/go.mod
+++ b/examples/stress/go.mod
@@ -1,6 +1,6 @@
 module client
 
-go 1.21
+go 1.23
 
 require (
 	github.com/scalyr/dataset-go v0.18.0
@@ -10,8 +10,8 @@ require (
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	go.opentelemetry.io/otel v1.27.0 // indirect
-	go.opentelemetry.io/otel/metric v1.27.0 // indirect
+	go.opentelemetry.io/otel v1.29.0 // indirect
+	go.opentelemetry.io/otel/metric v1.29.0 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/exp v0.0.0-20230626212559-97b1e661b5df // indirect
 )

--- a/examples/stress/go.sum
+++ b/examples/stress/go.sum
@@ -16,8 +16,10 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.opentelemetry.io/otel v1.27.0 h1:9BZoF3yMK/O1AafMiQTVu0YDj5Ea4hPhxCs7sGva+cg=
 go.opentelemetry.io/otel v1.27.0/go.mod h1:DMpAK8fzYRzs+bi3rS5REupisuqTheUlSZJ1WnZaPAQ=
+go.opentelemetry.io/otel v1.29.0/go.mod h1:N/WtXPs1CNCUEx+Agz5uouwCba+i+bJGFicT8SR4NP8=
 go.opentelemetry.io/otel/metric v1.27.0 h1:hvj3vdEKyeCi4YaYfNjv2NUje8FqKqUY8IlF0FxV/ik=
 go.opentelemetry.io/otel/metric v1.27.0/go.mod h1:mVFgmRlhljgBiuk/MP/oKylr4hs85GZAylncepAX/ak=
+go.opentelemetry.io/otel/metric v1.29.0/go.mod h1:auu/QWieFVWx+DmQOUMgj0F8LHWdgalxXqvp7BII/W8=
 go.opentelemetry.io/otel/trace v1.27.0 h1:IqYb813p7cmbHk0a5y6pD5JPakbVfftRXABGt5/Rscw=
 go.opentelemetry.io/otel/trace v1.27.0/go.mod h1:6RiD1hkAprV4/q+yd2ln1HG9GoPx39SuvvstaLBl+l4=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@
 
 module github.com/scalyr/dataset-go
 
-go 1.21
+go 1.23
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0


### PR DESCRIPTION
Go 1.21 is dead now. So lets deprecate it and use 1.23.
https://endoflife.date/go